### PR TITLE
Rename <x-bundle> to <x-import>

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -6,28 +6,7 @@ on:
     types: [completed]
 
 jobs:
-  skip-duplicates:
-    continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
-
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          # All of these options are optional, so you can remove them if you are happy with the defaults
-          cancel_others: "true"
-          concurrent_skipping: "same_content"
-          skip_after_successful_duplicate: "true"
-          paths_ignore: '["**/README.md", "**/docs/**"]'
-
   browser-tests:
-    needs: skip-duplicates
-    if: needs.skip-duplicates.outputs.should_skip != 'true'
-
     runs-on: ubuntu-latest
 
     steps:
@@ -63,5 +42,5 @@ jobs:
       - name: Install Bun & link Workbench directories
         run: composer setup-workbench
 
-      - name: Execute tests
+      - name: Run Dusk tests
         run: composer test-browser

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,10 @@
 name: tests
 
 on:
-  workflow_run:
-    workflows: [codestyle]
-    types: [completed]
+  push:
+    branches: [development, main]
+  pull_request:
+    branches: [development, main]
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Bun & link Workbench directories
         run: composer setup-workbench
 
-      - name: Execute tests - coverage threshold 90%
+      - name: Run tests - coverage threshold 90%
         run: composer test -- --coverage --min=90 --coverage-clover clover.xml
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,6 @@
 name: tests
 
 on:
-  push:
-    branches: [development, main]
   pull_request:
     branches: [development, main]
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bundle
+# `x-import`
 
 Effortless page specific JavaScript modules in Laravel/Livewire apps.
 
@@ -14,21 +14,21 @@ Effortless page specific JavaScript modules in Laravel/Livewire apps.
 ## Installation
 
 ```bash
-composer require leuverink/bundle
+composer require leuverink/x-import
 ```
 
 ```bash
 npm install bun --save-dev
 ```
 
-This is all you need to start using Bundle!
+This is all you need to start using x-import!
 
 ## Basic usage
 
 You may bundle any `node_module` or local script from your `resources/js` directory directly on the page.
 
 ```html
-<x-bundle import="apexcharts" as="ApexCharts" />
+<x-import module="apexcharts" as="ApexCharts" />
 
 <script type="module">
   const ApexCharts = await _bundle("ApexCharts");

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You may bundle any `node_module` or local script from your `resources/js` direct
 <x-import module="apexcharts" as="ApexCharts" />
 
 <script type="module">
-  const ApexCharts = await _bundle("ApexCharts");
+  const ApexCharts = await _import("ApexCharts");
 
   // Create something amazing!
 </script>

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Effortless page specific JavaScript modules in Laravel/Livewire apps.
 ## Installation
 
 ```bash
-composer require leuverink/x-import
+composer require leuverink/bundle
 ```
 
 ```bash
 npm install bun --save-dev
 ```
 
-This is all you need to start using x-import!
+This is all you need to start using Bundle!
 
 ## Basic usage
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: x-import
+title: Bundle
 description: Effortless page specific JavaScript modules in Laravel/Livewire apps
 remote_theme: just-the-docs/just-the-docs
 color_scheme: light

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Bundle
+title: x-import
 description: Effortless page specific JavaScript modules in Laravel/Livewire apps
 remote_theme: just-the-docs/just-the-docs
 color_scheme: light

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -47,7 +47,7 @@ In order to use this script directly in your blade views, you simply need to imp
 <x-import module="~/alert" as="alert" />
 
 <script type="module">
-  const module = await _bundle("alert");
+  const module = await _import("alert");
 
   module("Hello World!");
 </script>

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -10,7 +10,7 @@ You can render the bundle inline by using the `inline` option. This saves an add
 You should apply this with consideration. You will save up on requests, but doing so will increase the initial page load response size.
 
 ```html
-<x-bundle import="apexcharts" as="ApexCharts" inline />
+<x-import module="apexcharts" as="ApexCharts" inline />
 
 <!-- yields the following script -->
 
@@ -41,10 +41,10 @@ export default function alertProxy(message) {
 }
 ```
 
-In order to use this script directly in your blade views, you simply need to import it using the `<x-bundle />` component.
+In order to use this script directly in your blade views, you simply need to import it using the `<x-import />` component.
 
 ```html
-<x-bundle import="~/alert" as="alert" />
+<x-import module="~/alert" as="alert" />
 
 <script type="module">
   const module = await _bundle("alert");
@@ -58,9 +58,9 @@ In order to use this script directly in your blade views, you simply need to imp
 If a module supports per method exports, like `lodash` does, it is recomended to import the single method instead of the whole module & only retrieving the desired export later.
 
 ```html
-<x-bundle import="lodash/filter" as="filter" /> <!-- 25kb -->
+<x-import module="lodash/filter" as="filter" /> <!-- 25kb -->
 <!-- as opposed to -->
-<x-bundle import="lodash" as="lodash" /> <!-- 78kb -->
+<x-import module="lodash" as="lodash" /> <!-- 78kb -->
 ```
 
 ## Sourcemaps

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -58,11 +58,9 @@ In order to use this script directly in your blade views, you simply need to imp
 If a module supports per method exports, like `lodash` does, it is recomended to import the single method instead of the whole module & only retrieving the desired export later.
 
 ```html
-<x-import module="lodash/filter" as="filter" />
-<!-- 25kb -->
+<x-import module="lodash/filter" as="filter" /> <!-- 25kb -->
 <!-- as opposed to -->
-<x-import module="lodash" as="lodash" />
-<!-- 78kb -->
+<x-import module="lodash" as="lodash" /> <!-- 78kb -->
 ```
 
 ## Sourcemaps

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -58,9 +58,11 @@ In order to use this script directly in your blade views, you simply need to imp
 If a module supports per method exports, like `lodash` does, it is recomended to import the single method instead of the whole module & only retrieving the desired export later.
 
 ```html
-<x-import module="lodash/filter" as="filter" /> <!-- 25kb -->
+<x-import module="lodash/filter" as="filter" />
+<!-- 25kb -->
 <!-- as opposed to -->
-<x-import module="lodash" as="lodash" /> <!-- 78kb -->
+<x-import module="lodash" as="lodash" />
+<!-- 78kb -->
 ```
 
 ## Sourcemaps
@@ -80,7 +82,7 @@ You're free to tweak Cache-Control headers bundles are served with by publishing
 Bundle also adds a Last-Modified header in addition to naming the file based on it's hashed contents. This should cover most browser caching needs out of the box.
 
 ```
-Request URL: {your-domain}/x-bundle/e52def31336c.min.js
+Request URL: {your-domain}/x-import/e52def31336c.min.js
 
 Last-Modified: Fri, 12 Jan 2024, 19:00:00 UTC
 Cache-Control: max-age=31536000, immutable

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -9,7 +9,7 @@ A couple of things to be aware of.
 
 ### Tree shaking
 
-Tree shaking is currently not supported. Keep this in mind. When a module uses named exports the `x-bundle` component will inline all of it's exports.
+Tree shaking is currently not supported. Keep this in mind. When a module uses named exports the `x-import` component will inline all of it's exports.
 
 For example; when bundling lodash all of it's exports will be included in the bundle, regardless of if the export is used later down in your template. This effect can be mitigated by using the per-method import approach.
 

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -28,12 +28,12 @@ Due to Bun's path remapping behaviour Bundle is not able to split chunks from mo
 <!-- TODO: Add a detailed treeview of chunking vs how it's done now -->
 <!-- NOTE: A workaround where your local scripts also use _bundle() & we preload all dependencies in the blade template is possible. But less than ideal. -->
 
-### Don't pass dynamic variables to `<x-bundle />`
+### Don't pass dynamic variables to `<x-import />`
 
 This will work perfectly fine during development, but this can't be evaluated when compiling all your code for your production environment.
 
 ```html
-<x-bundle :import="$foo" as="{% raw %}{{ $bar }}{% endraw %}" />
+<x-import :import="$foo" as="{% raw %}{{ $bar }}{% endraw %}" />
 ```
 
 ### Prevent Bundle from loading the same import multiple times
@@ -42,4 +42,4 @@ Bundle uses laravel's `@once` direcive internally, so you don't have to worry ab
 
 ### Run `view:clear` after npm updates
 
-The title said it all. Not doing this _may_ result into issues where `<x-bundle>` serves old code.
+The title said it all. Not doing this _may_ result into issues where `<x-import>` serves old code.

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -26,7 +26,7 @@ If we were able to add code splitting we would be able to chunk these shared mod
 Due to Bun's path remapping behaviour Bundle is not able to split chunks from modules and assets imported from a path below it's internal project root (which is in the storage directory). If Bun fixes this issue this feature might be possible in the future.
 
 <!-- TODO: Add a detailed treeview of chunking vs how it's done now -->
-<!-- NOTE: A workaround where your local scripts also use _bundle() & we preload all dependencies in the blade template is possible. But less than ideal. -->
+<!-- NOTE: A workaround where your local scripts also use _import() & we preload all dependencies in the blade template is possible. But less than ideal. -->
 
 ### Don't pass dynamic variables to `<x-import />`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
 nav_order: 1
 title: Quickstart
+description: "Effortless page specific JavaScript modules in Laravel/Livewire apps"
 ---
 
 [![tests](https://github.com/gwleuverink/bundle/actions/workflows/tests.yml/badge.svg)](https://github.com/gwleuverink/bundle/actions/workflows/tests.yml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ This is all you need to start using Bundle!
 You may bundle any `node_module` or local script from your `resources/js` directory directly on the page.
 
 ```html
-<x-bundle import="apexcharts" as="ApexCharts" />
+<x-import module="apexcharts" as="ApexCharts" />
 
 <script type="module">
   const ApexCharts = await _bundle("ApexCharts");

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ You may bundle any `node_module` or local script from your `resources/js` direct
 <x-import module="apexcharts" as="ApexCharts" />
 
 <script type="module">
-  const ApexCharts = await _bundle("ApexCharts");
+  const ApexCharts = await _import("ApexCharts");
 
   // Create something amazing!
 </script>

--- a/docs/integrations/alpinejs.md
+++ b/docs/integrations/alpinejs.md
@@ -13,7 +13,7 @@ Using Bundle in AlpineJS is as easy as using it in an inline script.
 
 <button
   x-init="
-    let tippy = await _bundle('tippy')
+    let tippy = await _import('tippy')
     tippy($el, {
         content: 'Hello World!',
     });
@@ -23,7 +23,7 @@ Using Bundle in AlpineJS is as easy as using it in an inline script.
 </button>
 ```
 
-You can also use the `_bundle` function in the `x-data` object. This requires you make the funcion `_bundle` is invoked from async.
+You can also use the `_import` function in the `x-data` object. This requires you make the funcion `_import` is invoked from async.
 
 ```html
 <x-import module="tippy.js" as="tippy" defer />
@@ -31,7 +31,7 @@ You can also use the `_bundle` function in the `x-data` object. This requires yo
 <button
   x-data="{
     async init() {
-        let tippy = await _bundle('tippy')
+        let tippy = await _import('tippy')
         tippy($el, {
             content: 'Hello World!',
         });

--- a/docs/integrations/alpinejs.md
+++ b/docs/integrations/alpinejs.md
@@ -9,7 +9,7 @@ nav_order: 3
 Using Bundle in AlpineJS is as easy as using it in an inline script.
 
 ```html
-<x-bundle import="tippy.js" as="tippy" defer />
+<x-import module="tippy.js" as="tippy" defer />
 
 <button
   x-init="
@@ -26,7 +26,7 @@ Using Bundle in AlpineJS is as easy as using it in an inline script.
 You can also use the `_bundle` function in the `x-data` object. This requires you make the funcion `_bundle` is invoked from async.
 
 ```html
-<x-bundle import="tippy.js" as="tippy" defer />
+<x-import module="tippy.js" as="tippy" defer />
 
 <button
   x-data="{

--- a/docs/integrations/laravel.md
+++ b/docs/integrations/laravel.md
@@ -6,7 +6,7 @@ nav_order: 1
 
 ## Usage in plain Laravel
 
-When using Bundle in your Blade views, you may push/prepend `<x-bundle />` to a stack.
+When using Bundle in your Blade views, you may push/prepend `<x-import />` to a stack.
 
 Please refer to the [Laravel documentation](https://laravel.com/docs/10.x/blade#stacks){:target="\_blank"} for more information about using stacks.
 
@@ -16,7 +16,7 @@ Please refer to the [Laravel documentation](https://laravel.com/docs/10.x/blade#
 <!--  -->
 
 @push('scripts')
-<x-bundle import="apexcharts" as="ApexCharts" />
+<x-import module="apexcharts" as="ApexCharts" />
 @endstack
 ```
 
@@ -24,7 +24,7 @@ Bundle uses the `@once` directive internally, so there is no need to wrap the co
 
 ---
 
-After you've used the `<x-bundle>` in your template you can retreive the bundle inside any inline script.
+After you've used the `<x-import>` in your template you can retreive the bundle inside any inline script.
 
 ```html
 <script type="module">

--- a/docs/integrations/laravel.md
+++ b/docs/integrations/laravel.md
@@ -28,7 +28,7 @@ After you've used the `<x-import>` in your template you can retreive the bundle 
 
 ```html
 <script type="module">
-  const ApexCharts = await _bundle("ApexCharts");
+  const ApexCharts = await _import("ApexCharts");
 
   // Create something amazing!
 </script>

--- a/docs/integrations/livewire.md
+++ b/docs/integrations/livewire.md
@@ -12,6 +12,6 @@ Refer to the [Livewire docs](https://livewire.laravel.com/docs/javascript#using-
 
 ```html
 @script
-<x-bundle import="apexcharts" as="ApexCharts" />
+<x-import module="apexcharts" as="ApexCharts" />
 @endscript
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -12,7 +12,7 @@ The `<x-import />` component bundles your import on the fly using [Bun](https://
 
 <!-- yields the following script -->
 
-<script src="/x-bundle/e52def31336c.min.js" data-bundle="alert"></script>
+<script src="/x-import/e52def31336c.min.js" data-bundle="alert"></script>
 ```
 
 <br />

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,10 +5,10 @@ title: How it works
 
 ## How it works
 
-The `<x-bundle />` component bundles your import on the fly using [Bun](https://bun.sh){:target="\_blank"} and renders a script tag in place.
+The `<x-import />` component bundles your import on the fly using [Bun](https://bun.sh){:target="\_blank"} and renders a script tag in place.
 
 ```html
-<x-bundle import="apexcharts" as="ApexCharts" />
+<x-import module="apexcharts" as="ApexCharts" />
 
 <!-- yields the following script -->
 
@@ -25,7 +25,7 @@ The `<x-bundle />` component bundles your import on the fly using [Bun](https://
 
 ### The `_bundle()` helper function
 
-After you use `<x-bundle />` somewhere in your template a global `_bundle` function will become available on the window object.
+After you use `<x-import />` somewhere in your template a global `_bundle` function will become available on the window object.
 
 You can use this function to fetch the bundled import by the name you've passed to the `as` argument.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -23,29 +23,29 @@ The `<x-import />` component bundles your import on the fly using [Bun](https://
 
 <br />
 
-### The `_bundle()` helper function
+### The `_import()` helper function
 
-After you use `<x-import />` somewhere in your template a global `_bundle` function will become available on the window object.
+After you use `<x-import />` somewhere in your template a global `_import` function will become available on the window object.
 
 You can use this function to fetch the bundled import by the name you've passed to the `as` argument.
 
 ```js
-var module = await _bundle("lodash"); // Resolves the module's default export
+var module = await _import("lodash"); // Resolves the module's default export
 ```
 
-The `_bundle` function accepts a optional `export` argument which defaults to 'default'. When the module you're exporting uses named exports, you may resolve it like this:
+The `_import` function accepts a optional `export` argument which defaults to 'default'. When the module you're exporting uses named exports, you may resolve it like this:
 
 ```js
-var module = await _bundle("lodash", "filter"); // Resolves a named export 'filter'
+var module = await _import("lodash", "filter"); // Resolves a named export 'filter'
 ```
 
 _In cases like this it might be advantagious to use per-method imports instead. Please refer to the [advanced usage example](/bundle/advanced-usage.html#per-method-exports)._
 
 ---
 
-The `_bundle` function is async & returns a Promise. In order to use this in inline scripts you need to wrap it in a async function, or make the script tag you are using it in of `type="module"`.
+The `_import` function is async & returns a Promise. In order to use this in inline scripts you need to wrap it in a async function, or make the script tag you are using it in of `type="module"`.
 
-Please refer to the [advanced usage examples](/bundle/advanced-usage.html) for a more detailed explanation on how the `_bundle` function can be utilized in different scenarios.
+Please refer to the [advanced usage examples](/bundle/advanced-usage.html) for a more detailed explanation on how the `_import` function can be utilized in different scenarios.
 
 <br />
 

--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -29,7 +29,7 @@ class Build extends Command
             ->map(fn ($path) => $finder->in($path)->files()->name('*.blade.*'))
             // Map them to an array
             ->flatMap(fn (Finder $iterator) => iterator_to_array($iterator))
-            // Pregmatch each file for x-bundle components
+            // Pregmatch each file for x-import components
             ->flatMap(fn (SplFileInfo $file) => preg_grep('/<x-import.*?>$/', file($file)))
             // Trim whitespace
             ->map(fn ($component) => trim($component))

--- a/src/Commands/Build.php
+++ b/src/Commands/Build.php
@@ -30,13 +30,13 @@ class Build extends Command
             // Map them to an array
             ->flatMap(fn (Finder $iterator) => iterator_to_array($iterator))
             // Pregmatch each file for x-bundle components
-            ->flatMap(fn (SplFileInfo $file) => preg_grep('/<x-bundle.*?>$/', file($file)))
+            ->flatMap(fn (SplFileInfo $file) => preg_grep('/<x-import.*?>$/', file($file)))
             // Trim whitespace
             ->map(fn ($component) => trim($component))
             // Filter uniques
             ->unique()
             // Handle no no imports found
-            ->whenEmpty(fn () => warning('No usages of <x-bundle /> found in your build_paths.'))
+            ->whenEmpty(fn () => warning('No usages of <x-import /> found in your build_paths.'))
             // Start progress bar & render components
             ->whenNotEmpty(function ($components) {
                 // We can't display the task component status when it's invoked from within the progress bar

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -61,7 +61,7 @@ class Import extends Component
         $bundle = BundleManager::new()->bundle($js);
 
         // Render script tag with bundled code
-        return view('bundle::bundle', [
+        return view('x-import::import', [
             'bundle' => $bundle,
         ]);
     }

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -17,24 +17,9 @@ class Import extends Component
 
     public function render()
     {
-        // First make sure window.x_import_modules exists
-        // and assign the import to that object.
-        // ---------------------------------------------
-        // Then we expose a _import function that
-        // can retreive the module as a Promise
-        $js = <<< JS
-            if(!window.x_import_modules) window.x_import_modules = {}
-            window.x_import_modules.{$this->as} = import('{$this->module}')
-
-            window._import = async function(alias, exportName = 'default') {
-                let module = await window.x_import_modules[alias]
-                return module[exportName]
-            }
-        JS;
-
         // Bundle it up
         try {
-            return $this->bundle($js);
+            return $this->bundle();
         } catch (BundlingFailedException $e) {
             return $this->raiseConsoleErrorOrException($e);
         }
@@ -56,13 +41,26 @@ class Import extends Component
         HTML;
     }
 
-    protected function bundle(string $js)
+    protected function bundle()
     {
-        $bundle = BundleManager::new()->bundle($js);
+        // First make sure window.x_import_modules exists
+        // and assign the import to that object.
+        // ---------------------------------------------
+        // Then we expose a _import function that
+        // can retreive the module as a Promise
+        $js = <<< JS
+            if(!window.x_import_modules) window.x_import_modules = {}
+            window.x_import_modules.{$this->as} = import('{$this->module}')
+
+            window._import = async function(alias, exportName = 'default') {
+                let module = await window.x_import_modules[alias]
+                return module[exportName]
+            }
+        JS;
 
         // Render script tag with bundled code
         return view('x-import::import', [
-            'bundle' => $bundle,
+            'bundle' => BundleManager::new()->bundle($js),
         ]);
     }
 }

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -17,17 +17,17 @@ class Import extends Component
 
     public function render()
     {
-        // First make sure window._import_modules exists
+        // First make sure window.x_import_modules exists
         // and assign the import to that object.
         // ---------------------------------------------
         // Then we expose a _import function that
         // can retreive the module as a Promise
         $js = <<< JS
-            if(!window._import_modules) window._import_modules = {}
-            window._import_modules.{$this->as} = import('{$this->module}')
+            if(!window.x_import_modules) window.x_import_modules = {}
+            window.x_import_modules.{$this->as} = import('{$this->module}')
 
             window._import = async function(alias, exportName = 'default') {
-                let module = await window._import_modules[alias]
+                let module = await window.x_import_modules[alias]
                 return module[exportName]
             }
         JS;

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -17,17 +17,17 @@ class Import extends Component
 
     public function render()
     {
-        // First make sure window._bundle_modules exists
+        // First make sure window._import_modules exists
         // and assign the import to that object.
         // ---------------------------------------------
-        // Then we expose a _bundle function that
+        // Then we expose a _import function that
         // can retreive the module as a Promise
         $js = <<< JS
-            if(!window._bundle_modules) window._bundle_modules = {}
-            window._bundle_modules.{$this->as} = import('{$this->module}')
+            if(!window._import_modules) window._import_modules = {}
+            window._import_modules.{$this->as} = import('{$this->module}')
 
-            window._bundle = async function(alias, exportName = 'default') {
-                let module = await window._bundle_modules[alias]
+            window._import = async function(alias, exportName = 'default') {
+                let module = await window._import_modules[alias]
                 return module[exportName]
             }
         JS;

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -6,10 +6,10 @@ use Illuminate\View\Component;
 use Leuverink\Bundle\BundleManager;
 use Leuverink\Bundle\Exceptions\BundlingFailedException;
 
-class Bundle extends Component
+class Import extends Component
 {
     public function __construct(
-        public string $import,
+        public string $module,
         public string $as,
         public bool $inline = false // TODO: Implement this
     ) {
@@ -24,7 +24,7 @@ class Bundle extends Component
         // can retreive the module as a Promise
         $js = <<< JS
             if(!window._bundle_modules) window._bundle_modules = {}
-            window._bundle_modules.{$this->as} = import('{$this->import}')
+            window._bundle_modules.{$this->as} = import('{$this->module}')
 
             window._bundle = async function(alias, exportName = 'default') {
                 let module = await window._bundle_modules[alias]
@@ -50,8 +50,8 @@ class Bundle extends Component
         report($e);
 
         return <<< HTML
-            <!--[BUNDLE: {$this->as} from '{$this->import}']-->
-            <script data-bundle="{$this->as}">console.error('BUNDLING ERROR: import {$this->import} as {$this->as}')</script>
+            <!--[BUNDLE: {$this->as} from '{$this->module}']-->
+            <script data-bundle="{$this->as}">console.error('BUNDLING ERROR: import {$this->module} as {$this->as}')</script>
             <!--[ENDBUNDLE]>-->
         HTML;
     }

--- a/src/Components/views/import.blade.php
+++ b/src/Components/views/import.blade.php
@@ -6,7 +6,7 @@
     {!! file_get_contents($bundle) !!}
 </script>
 @else
-<script src="{{ route('x-bundle', $bundle->getFilename(), false) }}" data-bundle="{{ $as }}" {{ $attributes }}></script>
+<script src="{{ route('bundle:import', $bundle->getFilename(), false) }}" data-bundle="{{ $as }}" {{ $attributes }}></script>
 @endif
 <!--[ENDBUNDLE]>-->
 @else {{-- @once else clause --}}

--- a/src/Components/views/import.blade.php
+++ b/src/Components/views/import.blade.php
@@ -1,6 +1,6 @@
 <?php // @codeCoverageIgnoreStart ?>
 @once("bundle:$as")
-<!--[BUNDLE: {{ $as }} from '{{ $import }}']-->
+<!--[BUNDLE: {{ $as }} from '{{ $module }}']-->
 @if ($inline)
 <script data-bundle="{{ $as }}" {{ $attributes }}>
     {!! file_get_contents($bundle) !!}
@@ -10,6 +10,6 @@
 @endif
 <!--[ENDBUNDLE]>-->
 @else {{-- @once else clause --}}
-<!--[SKIPPED: {{ $as }} from '{{ $import }}']-->
+<!--[SKIPPED: {{ $as }} from '{{ $module }}']-->
 @endonce
 <?php // @codeCoverageIgnoreEnd ?>

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,7 +9,6 @@ use Leuverink\Bundle\Commands\Build;
 use Leuverink\Bundle\Commands\Clear;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
-use Leuverink\Bundle\Components\Bundle;
 use Leuverink\Bundle\Components\Import;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Leuverink\Bundle\Contracts\BundleManager as BundleManagerContract;
@@ -61,13 +60,13 @@ class ServiceProvider extends BaseServiceProvider
     protected function registerRoutes()
     {
         Route::get(
-            'x-bundle/{bundle}',
+            'x-import/{bundle}',
             fn ($bundle) => resolve(BundleManagerContract::class)->bundleContents($bundle)
-        )->name('x-bundle');
+        )->name('bundle:import');
 
         // TODO: Support code splitting
         // Route::get(
-        //     'x-bundle/chunks/{chunk}',
+        //     'x-import/chunks/{chunk}',
         //     fn($chunk) => resolve(BundleManagerContract::class)->chunkContents($chunk)
         // );
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,6 +10,7 @@ use Leuverink\Bundle\Commands\Clear;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Leuverink\Bundle\Components\Bundle;
+use Leuverink\Bundle\Components\Import;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Leuverink\Bundle\Contracts\BundleManager as BundleManagerContract;
 
@@ -47,8 +48,8 @@ class ServiceProvider extends BaseServiceProvider
 
     protected function registerComponents()
     {
-        $this->loadViewsFrom(__DIR__ . '/Components/views', 'bundle');
-        Blade::component('bundle', Bundle::class);
+        $this->loadViewsFrom(__DIR__ . '/Components/views', 'x-import');
+        Blade::component('import', Import::class);
     }
 
     protected function registerCommands()

--- a/tests/Browser/ComponentTest.php
+++ b/tests/Browser/ComponentTest.php
@@ -12,8 +12,8 @@ use Leuverink\Bundle\Tests\DuskTestCase;
 
 // it('renders the same import only once')
 //     ->blade(<<< HTML
-//         <x-bundle import="~/alert" as="alert" />
-//         <x-bundle import="~/alert" as="alert" />
+//         <x-import module="~/alert" as="alert" />
+//         <x-import module="~/alert" as="alert" />
 //     HTML)
 //     ->assertScript(<<< JS
 //         document.querySelectorAll('script[data-bundle="alert"').length
@@ -25,8 +25,8 @@ class ComponentTest extends DuskTestCase
     public function it_renders_the_same_import_only_once()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="~/alert" as="alert" />
-                <x-bundle import="~/alert" as="alert" />
+                <x-import module="~/alert" as="alert" />
+                <x-import module="~/alert" as="alert" />
             HTML)
             ->assertScript(<<< 'JS'
                 document.querySelectorAll('script[data-bundle="alert"').length
@@ -37,8 +37,8 @@ class ComponentTest extends DuskTestCase
     public function it_renders_the_same_import_only_once_when_one_was_inlined()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="~/alert" as="alert" />
-                <x-bundle import="~/alert" as="alert" inline />
+                <x-import module="~/alert" as="alert" />
+                <x-import module="~/alert" as="alert" inline />
             HTML)
             ->assertScript(<<< 'JS'
                 document.querySelectorAll('script[data-bundle="alert"').length
@@ -49,8 +49,8 @@ class ComponentTest extends DuskTestCase
     public function it_renders_the_same_import_under_different_aliases()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="~/alert" as="foo" />
-                <x-bundle import="~/alert" as="bar" />
+                <x-import module="~/alert" as="foo" />
+                <x-import module="~/alert" as="bar" />
             HTML)
             ->assertScript(<<< 'JS'
                 document.querySelectorAll('script[data-bundle="foo"').length
@@ -64,7 +64,7 @@ class ComponentTest extends DuskTestCase
     public function it_renders_script_inline_when_inline_prop_was_passed()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="~/alert" as="alert" inline />
+                <x-import module="~/alert" as="alert" inline />
             HTML)
             // Assert it doesn't render src attribute on the script tag
             ->assertScript(<<< 'JS'
@@ -79,7 +79,7 @@ class ComponentTest extends DuskTestCase
     public function it_doesnt_render_script_inline_by_default()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="~/alert" as="alert" />
+                <x-import module="~/alert" as="alert" />
             HTML)
             // Assert it renders src attribute on the script tag
             ->assertScript(<<< 'JS'
@@ -101,7 +101,7 @@ class ComponentTest extends DuskTestCase
         $this->expectException(ViewException::class);
 
         $this->blade(<<< 'HTML'
-            <x-bundle import="~/foo" as="bar" />
+            <x-import module="~/foo" as="bar" />
         HTML);
     }
 
@@ -115,7 +115,7 @@ class ComponentTest extends DuskTestCase
         $this->expectException(ViewException::class);
 
         $browser = $this->blade(<<< 'HTML'
-            <x-bundle import="~/foo" as="bar" />
+            <x-import module="~/foo" as="bar" />
         HTML);
 
         $this->assertEmpty($browser->driver->manage()->getLog('browser'));
@@ -129,7 +129,7 @@ class ComponentTest extends DuskTestCase
         });
 
         $this->blade(<<< 'HTML'
-            <x-bundle import="~/foo" as="bar" />
+            <x-import module="~/foo" as="bar" />
         HTML);
 
         $this->assertTrue(true); // No Exceptions raised
@@ -143,7 +143,7 @@ class ComponentTest extends DuskTestCase
         });
 
         $browser = $this->blade(<<< 'HTML'
-                <x-bundle import="~/foo" as="bar" />
+                <x-import module="~/foo" as="bar" />
             HTML)
             ->assertScript(<<< 'JS'
                 document.querySelectorAll('script[data-bundle="bar"')[0].innerHTML

--- a/tests/Browser/LocalModuleTest.php
+++ b/tests/Browser/LocalModuleTest.php
@@ -16,7 +16,7 @@ class LocalModuleTest extends DuskTestCase
                 <x-import module="~/alert" as="alert" />
             HTML)
             ->assertScript('typeof window._import', 'function')
-            ->assertScript('typeof window._import_modules', 'object');
+            ->assertScript('typeof window.x_import_modules', 'object');
     }
 
     /** @test */
@@ -34,7 +34,7 @@ class LocalModuleTest extends DuskTestCase
     }
 
     /** @test */
-    public function it_can_import_modules_per_method()
+    public function it_canx_import_modules_per_method()
     {
 
     }

--- a/tests/Browser/LocalModuleTest.php
+++ b/tests/Browser/LocalModuleTest.php
@@ -10,13 +10,13 @@ use Leuverink\Bundle\Tests\DuskTestCase;
 class LocalModuleTest extends DuskTestCase
 {
     /** @test */
-    public function it_injects_import_and_bundle_function_on_the_window_object()
+    public function it_injects_import_and_import_function_on_the_window_object()
     {
         $this->blade(<<< 'HTML'
                 <x-import module="~/alert" as="alert" />
             HTML)
-            ->assertScript('typeof window._bundle', 'function')
-            ->assertScript('typeof window._bundle_modules', 'object');
+            ->assertScript('typeof window._import', 'function')
+            ->assertScript('typeof window._import_modules', 'object');
     }
 
     /** @test */
@@ -26,7 +26,7 @@ class LocalModuleTest extends DuskTestCase
                 <x-import module="~/alert" as="alert" />
 
                 <script type="module">
-                    var module = await _bundle('alert');
+                    var module = await _import('alert');
                     module('Hello World!')
                 </script>
             HTML)

--- a/tests/Browser/LocalModuleTest.php
+++ b/tests/Browser/LocalModuleTest.php
@@ -13,7 +13,7 @@ class LocalModuleTest extends DuskTestCase
     public function it_injects_import_and_bundle_function_on_the_window_object()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="~/alert" as="alert" />
+                <x-import module="~/alert" as="alert" />
             HTML)
             ->assertScript('typeof window._bundle', 'function')
             ->assertScript('typeof window._bundle_modules', 'object');
@@ -23,7 +23,7 @@ class LocalModuleTest extends DuskTestCase
     public function it_imports_from_local_resource_directory()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="~/alert" as="alert" />
+                <x-import module="~/alert" as="alert" />
 
                 <script type="module">
                     var module = await _bundle('alert');

--- a/tests/Browser/NodeModuleTest.php
+++ b/tests/Browser/NodeModuleTest.php
@@ -13,7 +13,7 @@ class NodeModuleTest extends DuskTestCase
     public function it_injects_import_and_bundle_function_on_the_window_object()
     {
         $this->blade(<<< 'HTML'
-                <x-bundle import="lodash/filter" as="filter" />
+                <x-import module="lodash/filter" as="filter" />
             HTML)
             ->assertScript('typeof window._bundle', 'function')
             ->assertScript('typeof window._bundle_modules', 'object');
@@ -23,7 +23,7 @@ class NodeModuleTest extends DuskTestCase
     public function it_imports_from_node_modules()
     {
         $this->blade(<<< 'HTML'
-            <x-bundle import="lodash" as="lodash" />
+            <x-import module="lodash" as="lodash" />
 
             <script type="module">
                 const filter = await _bundle('lodash', 'filter');
@@ -50,7 +50,7 @@ class NodeModuleTest extends DuskTestCase
     public function it_can_import_modules_per_method()
     {
         $this->blade(<<< 'HTML'
-            <x-bundle import="lodash/filter" as="filter" />
+            <x-import module="lodash/filter" as="filter" />
 
             <script type="module">
                 const filter = await _bundle('filter');

--- a/tests/Browser/NodeModuleTest.php
+++ b/tests/Browser/NodeModuleTest.php
@@ -16,7 +16,7 @@ class NodeModuleTest extends DuskTestCase
                 <x-import module="lodash/filter" as="filter" />
             HTML)
             ->assertScript('typeof window._import', 'function')
-            ->assertScript('typeof window._import_modules', 'object');
+            ->assertScript('typeof window.x_import_modules', 'object');
     }
 
     /** @test */
@@ -47,7 +47,7 @@ class NodeModuleTest extends DuskTestCase
     }
 
     /** @test */
-    public function it_can_import_modules_per_method()
+    public function it_canx_import_modules_per_method()
     {
         $this->blade(<<< 'HTML'
             <x-import module="lodash/filter" as="filter" />

--- a/tests/Browser/NodeModuleTest.php
+++ b/tests/Browser/NodeModuleTest.php
@@ -10,13 +10,13 @@ use Leuverink\Bundle\Tests\DuskTestCase;
 class NodeModuleTest extends DuskTestCase
 {
     /** @test */
-    public function it_injects_import_and_bundle_function_on_the_window_object()
+    public function it_injects_import_and_import_function_on_the_window_object()
     {
         $this->blade(<<< 'HTML'
                 <x-import module="lodash/filter" as="filter" />
             HTML)
-            ->assertScript('typeof window._bundle', 'function')
-            ->assertScript('typeof window._bundle_modules', 'object');
+            ->assertScript('typeof window._import', 'function')
+            ->assertScript('typeof window._import_modules', 'object');
     }
 
     /** @test */
@@ -26,7 +26,7 @@ class NodeModuleTest extends DuskTestCase
             <x-import module="lodash" as="lodash" />
 
             <script type="module">
-                const filter = await _bundle('lodash', 'filter');
+                const filter = await _import('lodash', 'filter');
 
                 let data = [
                     { 'name': 'Foo', 'active': false },
@@ -53,7 +53,7 @@ class NodeModuleTest extends DuskTestCase
             <x-import module="lodash/filter" as="filter" />
 
             <script type="module">
-                const filter = await _bundle('filter');
+                const filter = await _import('filter');
 
                 let data = [
                     { 'name': 'Foo', 'active': false },

--- a/tests/Feature/IntegrationTest.php
+++ b/tests/Feature/IntegrationTest.php
@@ -122,13 +122,13 @@ it('serves bundles over http', function () {
     $file = $manager->hash($js) . '.min.js';
 
     $this->get(
-        route('x-bundle', $file)
+        route('bundle:import', $file)
     )->assertNotFound();
 
     $manager->bundle($js);
 
     $this->get(
-        route('x-bundle', $file)
+        route('bundle:import', $file)
     )->assertOk();
 });
 
@@ -142,7 +142,7 @@ it('serves bundles as Content-Type: application/javascript', function () {
     $manager->bundle($js);
 
     $this->get(
-        route('x-bundle', $file)
+        route('bundle:import', $file)
     )->assertHeader('Content-Type', 'application/javascript; charset=utf-8');
 });
 
@@ -156,7 +156,7 @@ it('serves bundles with Last-Modified headers', function () {
     $manager->bundle($js);
 
     $this->get(
-        route('x-bundle', $file)
+        route('bundle:import', $file)
     )->assertHeader('Last-Modified');
 });
 
@@ -172,7 +172,7 @@ it('serves bundles with configurable Cache-Control headers', function () {
     $manager->bundle($js);
 
     $this->get(
-        route('x-bundle', $file)
+        route('bundle:import', $file)
     )->assertHeader('Cache-Control', 'foo, private'); // private is added in laravel's cache-control middleware
 });
 

--- a/tests/Feature/IntegrationTest.php
+++ b/tests/Feature/IntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Leuverink\Bundle\BundleManager;
-use Leuverink\Bundle\Components\Bundle;
+use Leuverink\Bundle\Components\Import;
 use Leuverink\Bundle\Exceptions\BundlingFailedException;
 
 it('transpiles JavaScript')->bundle(
@@ -86,7 +86,7 @@ it('is able to resolve local scripts when aliased in jsconfig.json', function ()
 
 it('throws a BundlingFailedException when blade component fails bundling', function () {
     config()->set('app.debug', true);
-    $component = new Bundle('~/foo', 'bar');
+    $component = new Import('~/foo', 'bar');
 
     expect(fn () => $component->render())
         ->toThrow(BundlingFailedException::class);
@@ -94,7 +94,7 @@ it('throws a BundlingFailedException when blade component fails bundling', funct
 
 it('doesnt throw a BundlingFailedException when blade component fails bundling and debug mode is disabled', function () {
     config()->set('app.debug', false);
-    $component = new Bundle('~/foo', 'bar');
+    $component = new Import('~/foo', 'bar');
 
     expect(fn () => $component->render())
         ->not->toThrow(BundlingFailedException::class);
@@ -102,7 +102,7 @@ it('doesnt throw a BundlingFailedException when blade component fails bundling a
 
 it('raises console error when blade component fails bundling and debug mode is disabled', function () {
     config()->set('app.debug', false);
-    $component = new Bundle('~/foo', 'bar');
+    $component = new Import('~/foo', 'bar');
 
     expect($component->render())
         ->toContain(

--- a/tests/Fixtures/build-command-resources/index.blade.php
+++ b/tests/Fixtures/build-command-resources/index.blade.php
@@ -1,2 +1,2 @@
 {{-- Needs to exist inside configured build_path in order to be scanned by the bundle:build command --}}
-<x-bundle import="~/alert" as="alert" />
+<x-import module="~/alert" as="alert" />

--- a/tests/Fixtures/build-command-resources/markdown/index.blade.md
+++ b/tests/Fixtures/build-command-resources/markdown/index.blade.md
@@ -1,1 +1,1 @@
-<x-bundle import="~/alert" as="alert" />
+<x-import module="~/alert" as="alert" />

--- a/tests/Fixtures/build-command-resources/nested/index.blade.php
+++ b/tests/Fixtures/build-command-resources/nested/index.blade.php
@@ -1,1 +1,1 @@
-<x-bundle import="lodash/filter" as="filter" />
+<x-import module="lodash/filter" as="filter" />

--- a/workbench/resources/views/playground.blade.php
+++ b/workbench/resources/views/playground.blade.php
@@ -1,7 +1,7 @@
 <x-layout>
 
-    <x-bundle import="~/alert" as="alert" />
-    {{-- <x-bundle import="~/alert" as="alert" inline /> --}}
+    <x-import module="~/alert" as="alert" />
+    {{-- <x-import module="~/alert" as="alert" inline /> --}}
 
     <script type="module">
         var module = await _bundle('alert');

--- a/workbench/resources/views/playground.blade.php
+++ b/workbench/resources/views/playground.blade.php
@@ -4,7 +4,7 @@
     {{-- <x-import module="~/alert" as="alert" inline /> --}}
 
     <script type="module">
-        var module = await _bundle('alert');
+        var module = await _import('alert');
 
         module('Hello World!')
     </script>

--- a/workbench/resources/views/test/alpine-component-init-directive.blade.php
+++ b/workbench/resources/views/test/alpine-component-init-directive.blade.php
@@ -11,7 +11,7 @@
         }"
 
         x-init="
-            const filter = await _bundle('filter');
+            const filter = await _import('filter');
             let filtered = filter(users, o => !o.active)
             $el.innerHTML = JSON.stringify(filtered)
         "

--- a/workbench/resources/views/test/alpine-component-init-directive.blade.php
+++ b/workbench/resources/views/test/alpine-component-init-directive.blade.php
@@ -1,7 +1,7 @@
 <x-layout>
 
     <script src="//unpkg.com/alpinejs" defer></script>
-    <x-bundle import="lodash/filter" as="filter" />
+    <x-import module="lodash/filter" as="filter" />
 
     <div x-data="{
             users: [

--- a/workbench/resources/views/test/alpine-component-init-function.blade.php
+++ b/workbench/resources/views/test/alpine-component-init-function.blade.php
@@ -1,7 +1,7 @@
 <x-layout>
 
     <script src="//unpkg.com/alpinejs" defer></script>
-    <x-bundle import="lodash/filter" as="filter" />
+    <x-import module="lodash/filter" as="filter" />
 
     <div x-data="{
             users: [

--- a/workbench/resources/views/test/alpine-component-init-function.blade.php
+++ b/workbench/resources/views/test/alpine-component-init-function.blade.php
@@ -10,7 +10,7 @@
             ],
 
             async init() {
-                const filter = await _bundle('filter');
+                const filter = await _import('filter');
                 let filtered = filter(this.users, o => o.active)
                 $el.innerHTML = JSON.stringify(filtered)
             }

--- a/workbench/resources/views/test/local-import.blade.php
+++ b/workbench/resources/views/test/local-import.blade.php
@@ -4,7 +4,7 @@
     <x-import module="~/alert" as="alert" /> {{-- Should be skipped --}}
 
     <script type="module">
-        var module = await _bundle('alert');
+        var module = await _import('alert');
 
         module('Hello World!')
     </script>

--- a/workbench/resources/views/test/local-import.blade.php
+++ b/workbench/resources/views/test/local-import.blade.php
@@ -1,7 +1,7 @@
 <x-layout>
 
-    <x-bundle import="~/alert" as="alert" /> {{-- Should be rendered --}}
-    <x-bundle import="~/alert" as="alert" /> {{-- Should be skipped --}}
+    <x-import module="~/alert" as="alert" /> {{-- Should be rendered --}}
+    <x-import module="~/alert" as="alert" /> {{-- Should be skipped --}}
 
     <script type="module">
         var module = await _bundle('alert');

--- a/workbench/resources/views/test/node-module-named-import.blade.php
+++ b/workbench/resources/views/test/node-module-named-import.blade.php
@@ -1,6 +1,6 @@
 <x-layout>
 
-    <x-bundle import="lodash" as="lodash" />
+    <x-import module="lodash" as="lodash" />
 
     <script type="module">
         var filter = await _bundle('lodash', 'filter');

--- a/workbench/resources/views/test/node-module-named-import.blade.php
+++ b/workbench/resources/views/test/node-module-named-import.blade.php
@@ -3,7 +3,7 @@
     <x-import module="lodash" as="lodash" />
 
     <script type="module">
-        var filter = await _bundle('lodash', 'filter');
+        var filter = await _import('lodash', 'filter');
 
         var users = [
             { 'user': 'barney', 'age': 36, 'active': true },

--- a/workbench/resources/views/test/node-module-per-method-import.blade.php
+++ b/workbench/resources/views/test/node-module-per-method-import.blade.php
@@ -3,7 +3,7 @@
     <x-import module="lodash/filter" as="filter" />
 
     <script type="module">
-        var filter = await _bundle('filter');
+        var filter = await _import('filter');
 
         var users = [
             { 'user': 'barney', 'age': 36, 'active': true },

--- a/workbench/resources/views/test/node-module-per-method-import.blade.php
+++ b/workbench/resources/views/test/node-module-per-method-import.blade.php
@@ -1,6 +1,6 @@
 <x-layout>
 
-    <x-bundle import="lodash/filter" as="filter" />
+    <x-import module="lodash/filter" as="filter" />
 
     <script type="module">
         var filter = await _bundle('filter');


### PR DESCRIPTION
* Update all usages of `x-bundle import as` to `x-import module as`
* Keep `Bundle` as package name & namespace (since `Bundle` reads better than `XImport`)
* Update the docs
* CI workflow tweaks