### PR TITLE
Refactor/bun cli to js api

### DIFF
--- a/src/Bundlers/Bun.php
+++ b/src/Bundlers/Bun.php
@@ -20,28 +20,17 @@ class Bun implements Bundler
         bool $minify = true
     ): SplFileInfo {
 
-        $path = base_path('node_modules/.bin/');
+        $bun = base_path('node_modules/.bin/bun');
+        $buildScript = __DIR__ . '/bin/bun.js';
         $options = [
-            // '--splitting', // Breaks relative paths to imports from resources/js (TODO: Experiment more after writing tests)
-            '--chunk-naming' => 'chunks/[name]-[hash].[ext]', // Not in use without --splitting
-            '--asset-naming' => 'assets/[name]-[hash].[ext]', // Not in use without --splitting
-            '--entrypoints' => $inputPath . $fileName,
-            '--public-path' => $outputPath,
-            '--outdir' => $outputPath,
-            '--target' => 'browser',
-            '--root' => $inputPath,
-            '--format' => 'esm',
-
-            $sourcemaps
-                ? '--sourcemap=external'
-                : '--sourcemap=none',
-
-            $minify
-                ? '--minify'
-                : '',
+            '--entrypoint' => $inputPath . $fileName,
+            '--inputPath' => $inputPath,
+            '--outputPath' => $outputPath,
+            ...[$sourcemaps ? '--sourcemaps' : ''],
+            ...[$minify ? '--minify' : ''],
         ];
 
-        Process::run("{$path}bun build {$this->args($options)}")
+        Process::run("{$bun} {$buildScript} {$this->args($options)}")
             ->throw(function ($res) use ($inputPath, $fileName): void {
                 $failed = file_get_contents($inputPath . $fileName);
                 throw new BundlingFailedException($res, $failed);

--- a/src/Bundlers/bin/bun.js
+++ b/src/Bundlers/bin/bun.js
@@ -1,0 +1,56 @@
+import { parseArgs } from "util";
+
+const options = parseArgs({
+  args: Bun.argv,
+  strict: true,
+  allowPositionals: true,
+
+  options: {
+    entrypoint: {
+      type: "string",
+    },
+
+    inputPath: {
+      type: "string",
+    },
+
+    outputPath: {
+      type: "string",
+    },
+
+    sourcemaps: {
+      type: "boolean",
+    },
+
+    minify: {
+      type: "boolean",
+    },
+  },
+}).values;
+
+const result = await Bun.build({
+  entrypoints: [options.entrypoint],
+  publicPath: options.outputPath,
+  outdir: options.outputPath,
+  root: options.inputPath,
+  minify: options.minify,
+
+  sourcemap: options.sourcemaps ? "external" : "none",
+
+  naming: {
+    entry: '[dir]/[name].[ext]',
+    chunk: "chunks/[name]-[hash].[ext]", // Not in use without --splitting
+    asset: "assets/[name]-[hash].[ext]", // Not in use without --splitting
+  },
+
+  target: "browser",
+  format: "esm",
+});
+
+if (!result.success) {
+  console.error("Build failed");
+  for (const message of result.logs) {
+    console.error(message);
+  }
+  process.exit(1); // Exit with an error code
+}

--- a/tests/Browser/AlpineInteropTest.php
+++ b/tests/Browser/AlpineInteropTest.php
@@ -27,7 +27,7 @@ class AlpineInteropTest extends DuskTestCase
         // Doesn't raise console errors
         $this->assertEmpty($browser->driver->manage()->getLog('browser'));
 
-        $browser->assertSeeIn('#component', 'Hello World!');
+        $browser->waitForTextIn('#component', 'Hello World!');
     }
 
     /** @test */
@@ -48,7 +48,7 @@ class AlpineInteropTest extends DuskTestCase
         // Doesn't raise console errors
         $this->assertEmpty($browser->driver->manage()->getLog('browser'));
 
-        $browser->assertSeeIn('#component', 'Hello World!');
+        $browser->waitForTextIn('#component', 'Hello World!');
     }
 
     /** @test */
@@ -79,7 +79,7 @@ class AlpineInteropTest extends DuskTestCase
         // Doesn't raise console errors
         $this->assertEmpty($browser->driver->manage()->getLog('browser'));
 
-        $browser->assertSeeIn('#component', 'Fello World!');
+        $browser->waitForTextIn('#component', 'Fello World!');
 
     }
 
@@ -114,7 +114,7 @@ class AlpineInteropTest extends DuskTestCase
         // Doesn't raise console errors
         $this->assertEmpty($browser->driver->manage()->getLog('browser'));
 
-        $browser->assertSeeIn('#component', 'Gello World!');
+        $browser->waitForTextIn('#component', 'Gello World!');
     }
 
     /** @test */
@@ -144,9 +144,9 @@ class AlpineInteropTest extends DuskTestCase
         HTML);
 
         $browser
-            ->assertSeeIn('#component', 'Click to change text')
+            ->waitForTextIn('#component', 'Click to change text')
             ->press('#component')
-            ->assertSeeIn('#component', 'Cello World!');
+            ->waitForTextIn('#component', 'Cello World!');
 
         // Doesn't raise console errors
         $this->assertEmpty($browser->driver->manage()->getLog('browser'));
@@ -173,6 +173,6 @@ class AlpineInteropTest extends DuskTestCase
         // Doesn't raise console errors
         $this->assertEmpty($browser->driver->manage()->getLog('browser'));
 
-        $browser->assertSeeIn('#component', 'Hello backed component!');
+        $browser->waitForTextIn('#component', 'Hello backed component!');
     }
 }

--- a/tests/Browser/LivewireInteropTest.php
+++ b/tests/Browser/LivewireInteropTest.php
@@ -44,7 +44,7 @@ class LivewireInteropTest extends DuskTestCase
     {
         $browser = $this->serveLivewire(CanUseImportsFromXInit::class);
 
-        $browser->assertSeeIn('#component', 'Hello from x-init!');
+        $browser->waitForTextIn('#component', 'Hello from x-init!');
     }
 
     /** @test */
@@ -52,7 +52,7 @@ class LivewireInteropTest extends DuskTestCase
     {
         $browser = $this->serveLivewire(CanUseImportsFromXData::class);
 
-        $browser->assertSeeIn('#component', 'Hello from x-data!');
+        $browser->waitForTextIn('#component', 'Hello from x-data!');
     }
 
     /** @test */
@@ -61,9 +61,9 @@ class LivewireInteropTest extends DuskTestCase
         $browser = $this->serveLivewire(CanUseImportsFromClickListener::class);
 
         $browser
-            ->assertSeeIn('#component', 'Click to change text')
+            ->waitForTextIn('#component', 'Click to change text')
             ->press('#component')
-            ->assertSeeIn('#component', 'Hello from x-on:click!');
+            ->waitForTextIn('#component', 'Hello from x-on:click!');
     }
 
     /** @test */
@@ -72,9 +72,9 @@ class LivewireInteropTest extends DuskTestCase
         $browser = $this->serveLivewire(CanUseImportsFromAction::class);
 
         $browser
-            ->assertSeeIn('#component', 'Text changes when the Livewire action is invoked')
+            ->waitForTextIn('#component', 'Text changes when the Livewire action is invoked')
             ->waitForLivewire()->click('@action')
-            ->assertSeeIn('#component', 'Hello from wire action!');
+            ->waitForTextIn('#component', 'Hello from wire action!');
     }
 }
 

--- a/tests/Browser/LocalModuleTest.php
+++ b/tests/Browser/LocalModuleTest.php
@@ -50,7 +50,7 @@ class LocalModuleTest extends DuskTestCase
 
                 <div id="output"></div>
             HTML)
-            ->assertSeeIn('#output', 'Yello World!');
+            ->waitForTextIn('#output', 'Yello World!');
     }
 
     /** @test */
@@ -67,6 +67,6 @@ class LocalModuleTest extends DuskTestCase
 
             <div id="output"></div>
         HTML)
-            ->assertSeeIn('#output', 'Bar');
+            ->waitForTextIn('#output', 'Bar');
     }
 }

--- a/tests/Browser/NodeModuleTest.php
+++ b/tests/Browser/NodeModuleTest.php
@@ -43,7 +43,7 @@ class NodeModuleTest extends DuskTestCase
 
             <div id="output"></div>
         HTML)
-            ->assertSeeIn('#output', 'Hello World!');
+            ->waitForTextIn('#output', 'Hello World!');
     }
 
     /** @test */
@@ -70,7 +70,7 @@ class NodeModuleTest extends DuskTestCase
 
             <div id="output"></div>
         HTML)
-            ->assertSeeIn('#output', 'Yello World!');
+            ->waitForTextIn('#output', 'Yello World!');
     }
 
     /** @test */
@@ -98,6 +98,6 @@ class NodeModuleTest extends DuskTestCase
 
             <div id="output"></div>
         HTML)
-            ->assertSeeIn('#output', 'Wello World!');
+            ->waitForTextIn('#output', 'Wello World!');
     }
 }


### PR DESCRIPTION
This PR refactors the bun cli to js api.

This adds another layer, since we need to pass configuration to node process but allows us to have more control on how bun builds your bundles and opens the door to adding plugin support.

After this is merged I'm planning to write a css loader plugin. This is one of the bigger missing features I like to grok