### PR TITLE
Feature/css loader

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,6 +1,8 @@
 name: browser-tests
 
 on:
+  pull_request:
+    branches: [development, main]
   workflow_run:
     workflows: [tests]
     types: [completed]

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
             "cd ./workbench && npm ci",
             "ln -sf $PWD/workbench/jsconfig.json ./vendor/orchestra/testbench-core/laravel",
             "ln -sf $PWD/workbench/node_modules/ ./vendor/orchestra/testbench-core/laravel",
-            "ln -sf $PWD/workbench/resources/js/ ./vendor/orchestra/testbench-core/laravel/resources"
+            "ln -sf $PWD/workbench/resources/js/ ./vendor/orchestra/testbench-core/laravel/resources",
+            "ln -sf $PWD/workbench/resources/css/ ./vendor/orchestra/testbench-core/laravel/resources"
         ],
 
         "serve": [

--- a/config/bundle.php
+++ b/config/bundle.php
@@ -11,7 +11,7 @@ return [
     | and disable this on your local development environment.
     |
     */
-    'caching_enabled' => env('BUNDLE_CACHING_ENABLED', app()->isProduction()),
+    'caching' => env('BUNDLE_CACHING', app()->isProduction()),
 
     /*
     |--------------------------------------------------------------------------
@@ -47,7 +47,7 @@ return [
     | won't impact performance when your imports are build for prod.
     |
     */
-    'sourcemaps_enabled' => env('BUNDLE_SOURCEMAPS_ENABLED', false),
+    'sourcemaps' => env('BUNDLE_SOURCEMAPS', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/bundle.php
+++ b/config/bundle.php
@@ -11,7 +11,7 @@ return [
     | and disable this on your local development environment.
     |
     */
-    'caching' => env('BUNDLE_CACHING', app()->isProduction()),
+    'caching' => env('BUNDLE_CACHING', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -95,7 +95,7 @@ All code is minified by default. This can make issues harder to debug at times. 
 
 ## Sourcemaps
 
-Sourcemaps are disabled by default. You may enable this by setting `BUNDLE_SOURCEMAPS_ENABLED` to true in your env file or by publishing and updating the bundle config.
+Sourcemaps are disabled by default. You may enable this by setting `BUNDLE_SOURCEMAPS` to true in your env file or by publishing and updating the bundle config.
 
 Sourcemaps will be generated in a separate file so this won't affect performance for the end user.
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -149,8 +149,39 @@ BundleManager::fake();
 
 When you'd like to use Dusk for browser testing you need to run Bundle in order for your tests not to blow up. Simply don't fake the BundleManager in your DuskTestCase.
 
-## CSS Loader
+## CSS Loading
 
-Bun doesn't ship with a css loader. They have it on [the roadmap](https://github.com/oven-sh/bun/issues/159){:target="\_blank"} but no release date is known at this time. We plan to support css loading out-of-the-box as soon as Bun does!
+**Beta**
 
-We'd like to experiment with Bun plugin support soon. If that is released before Bun's builtin css loader does, it might be possible to write your own plugin to achieve this.
+Bun doesn't ship with a CSS loader. They have it on [the roadmap](https://github.com/oven-sh/bun/issues/159){:target="\_blank"} but no release date is known at this time. 
+
+We provide a custom CSS loader plugin that just works™. You only need to install [Lightning CSS](https://lightningcss.dev/), the rest is taken care of.
+
+``` bash
+npm install lightningcss --save-dev
+```
+
+Now you can import `css` & `scss` files. Bundle transpiles them and injects it on your page with zero effort.
+
+``` html
+<x-import module="tippy.js" as="tippy" />
+<x-import module="tippy.js/dist/tippy.css" />
+```
+
+### CSS browser targeting
+
+Bundle automatically compiles many modern CSS syntax features to more compatible output that is supported in your target browsers.
+
+You can define what browsers to target using your `package.json` file:
+
+``` json
+{
+	"browserslist": [
+        "last 2 versions",
+        ">= 1%",
+        "IE 11"
+    ]
+}
+```
+
+Note that this option only affects CSS transpilation. Bun does not support this at this time.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -149,39 +149,3 @@ BundleManager::fake();
 
 When you'd like to use Dusk for browser testing you need to run Bundle in order for your tests not to blow up. Simply don't fake the BundleManager in your DuskTestCase.
 
-## CSS Loading
-
-**Beta**
-
-Bun doesn't ship with a CSS loader. They have it on [the roadmap](https://github.com/oven-sh/bun/issues/159){:target="\_blank"} but no release date is known at this time. 
-
-We provide a custom CSS loader plugin that just works™. You only need to install [Lightning CSS](https://lightningcss.dev/), the rest is taken care of.
-
-``` bash
-npm install lightningcss --save-dev
-```
-
-Now you can import `css` & `scss` files. Bundle transpiles them and injects it on your page with zero effort.
-
-``` html
-<x-import module="tippy.js" as="tippy" />
-<x-import module="tippy.js/dist/tippy.css" />
-```
-
-### CSS browser targeting
-
-Bundle automatically compiles many modern CSS syntax features to more compatible output that is supported in your target browsers.
-
-You can define what browsers to target using your `package.json` file:
-
-``` json
-{
-	"browserslist": [
-        "last 2 versions",
-        ">= 1%",
-        "IE 11"
-    ]
-}
-```
-
-Note that this option only affects CSS transpilation. Bun does not support this at this time.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -101,7 +101,7 @@ Sourcemaps will be generated in a separate file so this won't affect performance
 
 {: .note }
 
-> If your project stored previously bundled files you need to run the [bundle:clear](https://laravel-bundle.dev/advanced-usage.html#artisan-bundleclear) command
+> If your project stored previously bundled files you need to run the [bundle:clear](https://laravel-bundle.dev/advanced-usage.html#artisan-bundleclear) command after enabling/disabling this feature.
 
 ## Cache-Control headers
 
@@ -148,4 +148,3 @@ BundleManager::fake();
 ```
 
 When you'd like to use Dusk for browser testing you need to run Bundle in order for your tests not to blow up. Simply don't fake the BundleManager in your DuskTestCase.
-

--- a/docs/caveats.md
+++ b/docs/caveats.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 7
+nav_order: 8
 title: Caveats
 image: "/assets/social-square.png"
 ---

--- a/docs/css-loading.md
+++ b/docs/css-loading.md
@@ -10,18 +10,30 @@ image: "/assets/social-square.png"
 
 Bun doesn't ship with a CSS loader. They have it on [the roadmap](https://github.com/oven-sh/bun/issues/159){:target="\_blank"} but no release date is known at this time.
 
-We provide a custom CSS loader plugin that just works™. You only need to install [Lightning CSS](https://lightningcss.dev/), the rest is taken care of.
-
-```bash
-npm install lightningcss --save-dev
-```
-
-Now you can import `css` files. Bundle transpiles them and injects it on your page with zero effort.
+We provide a custom CSS loader plugin that just works™. Built on top of [Lightning CSS](https://lightningcss.dev/). Just use the `x-import` directive to load a css file directly. Bundle transpiles them and injects it on your page with zero effort.
 
 ```html
 <x-import module="tippy.js" as="tippy" />
 <x-import module="tippy.js/dist/tippy.css" />
 ```
+
+Because we use Bun as a runtime when processing your files there is no need to install Lightning CSS as a dependency. When Bun encounters a import that is not installed it will fall back to it's on internal [module resolution algorithm](https://bun.sh/docs/runtime/autoimport) & install the dependency on the fly.
+
+That being said; We do recommend installing Lightning CSS in your project.
+
+```bash
+npm install lightningcss --save-dev
+```
+
+### Sass
+
+[Sass](https://sass-lang.com/) is supported out of the box. Just like with Lightning CSS you don't have to install Sass as a dependency, but it is recommended.
+
+```bash
+npm install lightningcss --save-dev
+```
+
+Note that compiled Sass is processed with LightningCSS afterwards, so if you plan on only processing scss files it is recommended to install both Lightning CSS & Sass.
 
 ### Local CSS loading
 
@@ -55,12 +67,8 @@ You can define what browsers to target using your `package.json` file:
 }
 ```
 
-### Sass
+<br/>
 
-In order to load `scss` files you need to install [Sass](https://sass-lang.com/) as a dependency.
+{: .note }
 
-```bash
-npm install lightningcss --save-dev
-```
-
-Bundle will detect Sass is installed and enable bundling scss files with zero configuration.
+> Bundle currently only supports browserslist using your `package.json` file. A dedicated `.browserslistrc` is not suppported at this time.

--- a/docs/css-loading.md
+++ b/docs/css-loading.md
@@ -1,0 +1,66 @@
+---
+nav_order: 5
+title: CSS loading
+image: "/assets/social-square.png"
+---
+
+## CSS Loading
+
+**Beta**
+
+Bun doesn't ship with a CSS loader. They have it on [the roadmap](https://github.com/oven-sh/bun/issues/159){:target="\_blank"} but no release date is known at this time.
+
+We provide a custom CSS loader plugin that just works™. You only need to install [Lightning CSS](https://lightningcss.dev/), the rest is taken care of.
+
+```bash
+npm install lightningcss --save-dev
+```
+
+Now you can import `css` files. Bundle transpiles them and injects it on your page with zero effort.
+
+```html
+<x-import module="tippy.js" as="tippy" />
+<x-import module="tippy.js/dist/tippy.css" />
+```
+
+### Local CSS loading
+
+This works similar to [local modules](https://laravel-bundle.dev/local-modules.html). Simply add a new path alias to your `jsconfig.json` file.
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "~/css": ["./resources/css/*"]
+    }
+  }
+}
+```
+
+Now you can load css from your resources directory.
+
+```html
+<x-import module="css/foo-bar.css" />
+```
+
+### Browser targeting
+
+Bundle automatically compiles many modern CSS syntax features to more compatible output that is supported in your target browsers. This includes some features that are not supported by browsers yet, like nested selectors & media queries, without using a preprocessor like Sass. [Check here](https://lightningcss.dev/transpilation.html#syntax-lowering) for the list of the many cool new syntaxes Lightning CSS supports.
+
+You can define what browsers to target using your `package.json` file:
+
+```json
+{
+  "browserslist": ["last 2 versions", ">= 1%", "IE 11"]
+}
+```
+
+### Sass
+
+In order to load `scss` files you need to install [Sass](https://sass-lang.com/) as a dependency.
+
+```bash
+npm install lightningcss --save-dev
+```
+
+Bundle will detect Sass is installed and enable bundling scss files with zero configuration.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 6
+nav_order: 7
 has_children: true
 title: Integration examples
 image: "/assets/social-square.png"

--- a/docs/production-builds.md
+++ b/docs/production-builds.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 5
+nav_order: 6
 title: Production builds
 image: "/assets/social-square.png"
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,15 @@ image: "/assets/social-square.png"
 
 Bundle is under active development. If you feel there are features missing or you've got a great idea that's not on on the roadmap please [open a discussion](https://github.com/gwleuverink/bundle/discussions/categories/ideas){:target="\_blank"} on GitHub.
 
-## CSS loader
+## ✅ Injecting Bundle's core on every page
+
+**_Added in [v0.1.3](https://github.com/gwleuverink/bundle/releases/tag/v0.1.3)_**
+
+This will reduce every import's size slightly. But more importantly; it will greatly decrease the chance of unexpected behaviour caused by race conditions, since the Bundle's core is available on pageload.
+
+## ✅ CSS loader
+
+**_Added in [v0.1.4](https://github.com/gwleuverink/bundle/releases/tag/v0.1.4)_**
 
 Bun doesn't ship with a css loader. They have it on [the roadmap](https://github.com/oven-sh/bun/issues/159){:target="\_blank"} but no release date is known at this time. We plan to support css loading out-of-the-box as soon as Bun does!
 
@@ -101,12 +109,6 @@ It would be incredible if this object could be forwarded to Alpine directly like
   <div x-show="open">Content...</div>
 </div>
 ```
-
-## ✅ Injecting Bundle's core on every page
-
-**_Added in [v0.1.3](https://github.com/gwleuverink/bundle/releases/tag/v0.1.3)_**
-
-This will reduce every import's size slightly. But more importantly; it will greatly decrease the chance of unexpected behaviour caused by race conditions, since the Bundle's core is available on pageload.
 
 ## Optionally assigning a import to the window scope
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,5 @@
 ---
-nav_order: 8
+nav_order: 9
 title: Roadmap
 image: "/assets/social-square.png"
 ---

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,11 +4,18 @@
          bootstrap="vendor/autoload.php"
          colors="true"
 >
+    <php>
+        <env name="BUNDLE_MINIFY" value="true" />
+        <env name="BUNDLE_CACHING" value="false" />
+        <env name="BUNDLE_SOURCEMAPS" value="false" />
+    </php>
+
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+
     <source>
         <include>
             <directory suffix=".php">./app</directory>

--- a/src/BundleManager.php
+++ b/src/BundleManager.php
@@ -34,7 +34,7 @@ class BundleManager implements BundleManagerContract
         $file = "{$this->hash($script)}.min.js";
 
         // Return cached file if available
-        if ($this->config()->get('caching_enabled') && $cached = $this->fromDisk($file)) {
+        if ($this->config()->get('caching') && $cached = $this->fromDisk($file)) {
             return $cached;
         }
 
@@ -44,7 +44,7 @@ class BundleManager implements BundleManagerContract
         // Attempt bundling & cleanup
         try {
             $processed = $this->bundler->build(
-                sourcemaps: $this->config()->get('sourcemaps_enabled'),
+                sourcemaps: $this->config()->get('sourcemaps'),
                 minify: $this->config()->get('minify'),
                 inputPath: $this->tempDisk()->path(''),
                 outputPath: $this->buildDisk()->path(''),

--- a/src/BundleManager.php
+++ b/src/BundleManager.php
@@ -31,7 +31,11 @@ class BundleManager implements BundleManagerContract
 
     public function bundle(string $script): SplFileInfo
     {
-        $file = "{$this->hash($script)}.min.js";
+        $min = $this->config()->get('minify')
+            ? '.min'
+            : '';
+
+        $file = "{$this->hash($script)}{$min}.js";
 
         // Return cached file if available
         if ($this->config()->get('caching') && $cached = $this->fromDisk($file)) {

--- a/src/Bundlers/Bun/Bun.php
+++ b/src/Bundlers/Bun/Bun.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Leuverink\Bundle\Bundlers;
+namespace Leuverink\Bundle\Bundlers\Bun;
 
 use SplFileInfo;
 use Illuminate\Support\Facades\Process;

--- a/src/Bundlers/Bun/Bun.php
+++ b/src/Bundlers/Bun/Bun.php
@@ -33,6 +33,8 @@ class Bun implements Bundler
         Process::run("{$bun} {$buildScript} {$this->args($options)}")
             ->throw(function ($res) use ($inputPath, $fileName): void {
                 $failed = file_get_contents($inputPath . $fileName);
+
+                // TODO: needs to be reworked
                 throw new BundlingFailedException($res, $failed);
             });
 

--- a/src/Bundlers/Bun/bin/bun.js
+++ b/src/Bundlers/Bun/bin/bun.js
@@ -49,8 +49,8 @@ const result = await Bun.build({
 
     plugins: [
         cssLoader({
-            minify: options.minify,
-            sourcemaps: options.sourcemaps
+            minify: Boolean(options.minify),
+            sourcemaps: Boolean(options.sourcemaps)
         })
     ]
 });

--- a/src/Bundlers/Bun/bin/bun.js
+++ b/src/Bundlers/Bun/bin/bun.js
@@ -2,60 +2,63 @@ import { parseArgs } from "util";
 import cssLoader from "./plugins/css-loader";
 
 const options = parseArgs({
-  args: Bun.argv,
-  strict: true,
-  allowPositionals: true,
+    args: Bun.argv,
+    strict: true,
+    allowPositionals: true,
 
-  options: {
-    entrypoint: {
-      type: "string",
-    },
+    options: {
+        entrypoint: {
+            type: "string",
+        },
 
-    inputPath: {
-      type: "string",
-    },
+        inputPath: {
+            type: "string",
+        },
 
-    outputPath: {
-      type: "string",
-    },
+        outputPath: {
+            type: "string",
+        },
 
-    sourcemaps: {
-      type: "boolean",
-    },
+        sourcemaps: {
+            type: "boolean",
+        },
 
-    minify: {
-      type: "boolean",
+        minify: {
+            type: "boolean",
+        },
     },
-  },
 }).values;
 
 const result = await Bun.build({
-  entrypoints: [options.entrypoint],
-  publicPath: options.outputPath,
-  outdir: options.outputPath,
-  root: options.inputPath,
-  minify: options.minify,
+    entrypoints: [options.entrypoint],
+    publicPath: options.outputPath,
+    outdir: options.outputPath,
+    root: options.inputPath,
+    minify: options.minify,
 
-  sourcemap: options.sourcemaps ? "external" : "none",
+    sourcemap: options.sourcemaps ? "external" : "none",
 
-  naming: {
-    entry: '[dir]/[name].[ext]',
-    chunk: "chunks/[name]-[hash].[ext]", // Not in use without --splitting
-    asset: "assets/[name]-[hash].[ext]", // Not in use without --splitting
-  },
+    naming: {
+        entry: '[dir]/[name].[ext]',
+        chunk: "chunks/[name]-[hash].[ext]", // Not in use without --splitting
+        asset: "assets/[name]-[hash].[ext]", // Not in use without --splitting
+    },
 
-  target: "browser",
-  format: "esm",
+    target: "browser",
+    format: "esm",
 
-  plugins: [
-    cssLoader()
-  ]
+    plugins: [
+        cssLoader({
+            minify: options.minify,
+            sourcemaps: options.sourcemaps
+        })
+    ]
 });
 
 if (!result.success) {
-  console.error("Build failed");
-  for (const message of result.logs) {
-    console.error(message);
-  }
-  process.exit(1); // Exit with an error code
+    console.error("Build failed");
+    for (const message of result.logs) {
+        console.error(message);
+    }
+    process.exit(1); // Exit with an error code
 }

--- a/src/Bundlers/Bun/bin/bun.js
+++ b/src/Bundlers/Bun/bin/bun.js
@@ -1,7 +1,7 @@
 // NOTE: we don't have to check if Bun is installed sinsce this script is invoked with the Bun runtime
 
 import { parseArgs } from "util";
-import { error } from "./utils/dump";
+import { exit } from "./utils/dump";
 import cssLoader from "./plugins/css-loader";
 
 const options = parseArgs({
@@ -64,5 +64,6 @@ if (!result.success) {
     // }
     // process.exit(1);
 
-    error('build-failed', '', result.logs.map(log => log.message))
+    // TODO: needs to be reworked
+    exit('build-failed', '', result.logs.map(log => log.message))
 }

--- a/src/Bundlers/Bun/bin/bun.js
+++ b/src/Bundlers/Bun/bin/bun.js
@@ -1,4 +1,5 @@
 import { parseArgs } from "util";
+import cssLoader from "./plugins/css-loader";
 
 const options = parseArgs({
   args: Bun.argv,
@@ -45,6 +46,10 @@ const result = await Bun.build({
 
   target: "browser",
   format: "esm",
+
+  plugins: [
+    cssLoader()
+  ]
 });
 
 if (!result.success) {

--- a/src/Bundlers/Bun/bin/bun.js
+++ b/src/Bundlers/Bun/bin/bun.js
@@ -1,4 +1,7 @@
+// NOTE: we don't have to check if Bun is installed sinsce this script is invoked with the Bun runtime
+
 import { parseArgs } from "util";
+import { error } from "./utils/dump";
 import cssLoader from "./plugins/css-loader";
 
 const options = parseArgs({
@@ -39,7 +42,7 @@ const result = await Bun.build({
     sourcemap: options.sourcemaps ? "external" : "none",
 
     naming: {
-        entry: '[dir]/[name].[ext]',
+        entry: "[dir]/[name].[ext]",
         chunk: "chunks/[name]-[hash].[ext]", // Not in use without --splitting
         asset: "assets/[name]-[hash].[ext]", // Not in use without --splitting
     },
@@ -50,15 +53,16 @@ const result = await Bun.build({
     plugins: [
         cssLoader({
             minify: Boolean(options.minify),
-            sourcemaps: Boolean(options.sourcemaps)
-        })
-    ]
+            sourcemaps: Boolean(options.sourcemaps),
+        }),
+    ],
 });
 
 if (!result.success) {
-    console.error("Build failed");
-    for (const message of result.logs) {
-        console.error(message);
-    }
-    process.exit(1); // Exit with an error code
+    // for (const message of result.logs) {
+    //     console.error(message);
+    // }
+    // process.exit(1);
+
+    error('build-failed', '', result.logs.map(log => log.message))
 }

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -1,0 +1,91 @@
+const [css, sass, fs] = await Promise.all([
+    import("lightningcss-wasm"),
+    import("sass"),
+    import("fs")
+]);
+
+const defaultOptions = {
+  targets: [],
+};
+
+export default function (options = {}) {
+  const opts = { ...defaultOptions, ...options };
+
+  return {
+    name: "Bundle CSS loader",
+    async setup(build) {
+
+      // Build plain css
+      build.onLoad({ filter: /\.css$/ }, (args) => {
+
+        const contents = fs.readFileSync(args.path, "utf8");
+
+        return compile(contents, args.path, {
+          targets: opts.targets,
+        });
+      });
+
+      // Build sass
+      build.onLoad({ filter: /\.scss$/ }, (args) => {
+
+        if(!sass) {
+            throw `BUNDLING ERROR: You need to install sass in order to support sass loading`
+        }
+
+        const result = sass.compile(args.path);
+
+        return compile(result.css, args.path, {
+          targets: opts.targets,
+        });
+      });
+    },
+  };
+}
+
+async function compile(content, path, options = {}) {
+
+    if(!css) {
+      throw `BUNDLING ERROR: You need to install lightning CSS in order to support CSS loading`
+    }
+
+    const imports = [];
+    const targets = options.targets?.length
+      ? css.browserslistToTargets(options.targets)
+      : undefined;
+
+    const { code, exports } = css.transform({
+      filename: path,
+      code: Buffer.from(content),
+      cssModules: Boolean(options.cssModules),
+      minify: true,
+      targets,
+      visitor: {
+        Rule: {
+          import(rule) {
+            imports.push(rule.value.url);
+            return [];
+          },
+        },
+      },
+    });
+
+
+    if (imports.length === 0) {
+      return {
+        contents: `export default ${JSON.stringify(code.toString())};`,
+        loader: "js",
+      };
+    }
+
+    const imported = imports
+      .map((url, i) => `import _css${i} from "${url}";`)
+      .join("\n");
+    const exported = imports.map((_, i) => `_css${i}`).join(" + ");
+
+    return {
+      contents: `${imported}\nexport default ${exported} + ${JSON.stringify(
+        code.toString()
+      )};`,
+      loader: "js",
+    };
+  }

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -12,8 +12,10 @@ export default function (options = {}) {
     return {
         name: "css-loader",
         async setup(build) {
-            build.onLoad({ filter: /\.css$|\.scss$/ }, async (args) => {
-                const expression = await compile(args, {
+            build.onLoad({ filter: /\.css$/ }, async (args) => {
+                const source = await readFile(args.path, "utf8");
+
+                const expression = await compile(source, args.path, {
                     ...defaultOptions,
                     ...options,
                 });
@@ -27,14 +29,14 @@ export default function (options = {}) {
     };
 }
 
-const compile = async function (args, opts) {
+const compile = async function (source, filename, opts) {
     const imports = [];
-    const source = await readFile(args.path, "utf8");
+
     const targets = await determineTargets(opts.browserslist);
 
     const { code } = transform({
         targets,
-        filename: args.path,
+        filename,
         code: Buffer.from(source),
 
         minify: opts.minify,

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -1,34 +1,33 @@
-import { transform, browserslistToTargets } from "lightningcss-wasm";
-import { readFile, exists } from "fs/promises";
-import path from "path";
+import determineTargets from "./../utils/browser-targets";
+import { transform } from "lightningcss-wasm";
+import { readFile } from "fs/promises";
 
 const defaultOptions = {
     browserslist: [],
     minify: true,
-    sourcemaps: false
+    sourcemaps: false,
 };
 
 export default function (options = {}) {
-
     return {
         name: "css-loader",
         async setup(build) {
-
             build.onLoad({ filter: /\.css$|\.scss$/ }, async (args) => {
-
-                const expression = await compile(args, { ...defaultOptions, ...options })
+                const expression = await compile(args, {
+                    ...defaultOptions,
+                    ...options,
+                });
 
                 return {
                     contents: expression,
                     loader: "js",
-                }
-            })
-        }
-    }
+                };
+            });
+        },
+    };
 }
 
 const compile = async function (args, opts) {
-
     const imports = [];
     const source = await readFile(args.path, "utf8");
     const targets = await determineTargets(opts.browserslist);
@@ -52,81 +51,20 @@ const compile = async function (args, opts) {
         },
     });
 
-    const css = JSON.stringify(code.toString())
-    const imported = imports.map((url, i) => `import _css${i} from "${url}";`).join("\n");
-    const exported = imports.map((_, i) => `_css${i}`).join(" + ");
+    const css = JSON.stringify(code.toString());
 
     // No CSS imports. Return processed file
     if (!imports.length) {
-        return `export default ${css}`
+        return `export default ${css}`;
     }
 
     // Has both imports & CSS rules in processed file
+    const imported = imports
+        .map((url, i) => `import _css${i} from "${url}";`)
+        .join("\n");
+
+    const exported = imports.map((_, i) => `_css${i}`)
+        .join(" + ");
+
     return `${imported}\nexport default ${exported} + ${css}`;
-}
-
-
-//--------------------------------------------------------------------------
-// Utilities
-//--------------------------------------------------------------------------
-
-/**
- * Use targets from config or when none given try
- * to detect browserslist from package.json
- */
-const determineTargets = async function (browserslist) {
-
-    if (browserslist?.length) {
-        return browserslistToTargets(browserslist)
-    }
-
-    // read from package.json
-    const pkg = await packageJson()
-    browserslist = pkg.browserslist || []
-
-    if (browserslist?.length) {
-        return browserslistToTargets(browserslist)
-    }
-
-    return undefined
-}
-
-/**
- * Get contents of nearest package.json
- */
-const packageJson = async function () {
-
-    try {
-        const path = await findNearestPackageJson();
-        const content = await readFile(path, 'utf8');
-        return JSON.parse(content);
-    } catch (error) {
-        console.error('Error reading browserslist from package.json:', error.message);
-        return [];
-    }
-
-}
-
-/**
- * Get path of nearest package.json
- */
-const findNearestPackageJson = async function () {
-
-    let currentDir = process.cwd();
-
-    while (true) {
-
-        const packageJsonPath = path.join(currentDir, 'package.json');
-
-        if (await exists(packageJsonPath)) {
-            return packageJsonPath;
-        }
-
-        // package.json file could not be found.
-        if (currentDir === path.dirname(currentDir)) {
-            return null;
-        }
-
-        currentDir = path.dirname(currentDir);
-    }
-}
+};

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -1,4 +1,4 @@
-import dd from "./../utils/dd";
+import { dd, error } from "./../utils/dump";
 import determineTargets from "./../utils/browser-targets";
 import { readFile } from "fs/promises";
 
@@ -31,8 +31,7 @@ export default function (options = {}) {
             // Compile sass pass output through Lightning CSS
             build.onLoad({ filter: /\.scss$/ }, async (args) => {
                 const sass = await import('sass').catch(error => {
-                    console.error('bundle:sass-not-installed')
-                    process.exit(1)
+                    error('sass-not-installed')
                 })
 
                 const source = sass.compile(args.path)
@@ -54,8 +53,7 @@ export default function (options = {}) {
 const compile = async function (source, filename, opts) {
 
     const lightningcss = await import("lightningcss-wasm").catch(error => {
-        console.error('bundle:lightningcss-not-installed')
-        process.exit(1)
+        error('lightningcss-not-installed')
     })
 
     const imports = [];

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -40,7 +40,8 @@ const compile = async function (args, opts) {
         code: Buffer.from(source),
 
         minify: opts.minify,
-        sourceMap: opts.sourcemaps,
+        // sourceMap: opts.sourcemaps,
+        sourceMap: false, // Files not generated. must handle artifacts manually. disable for now
 
         visitor: {
             Rule: {

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -1,5 +1,5 @@
 import determineTargets from "./../utils/browser-targets";
-import { error } from "./../utils/dump";
+import { exit } from "./../utils/dump";
 import { readFile } from "fs/promises";
 
 const defaultOptions = {
@@ -30,7 +30,7 @@ export default function (options = {}) {
             // Compile sass pass output through Lightning CSS
             build.onLoad({ filter: /\.scss$/ }, async (args) => {
                 const sass = await import("sass").catch((error) => {
-                    error("sass-not-installed");
+                    exit("sass-not-installed");
                 });
 
                 const source = sass.compile(args.path);
@@ -51,7 +51,7 @@ export default function (options = {}) {
 
 const compile = async function (source, filename, opts) {
     const lightningcss = await import("lightningcss-wasm").catch((error) => {
-        error("lightningcss-not-installed");
+        exit("lightningcss-not-installed");
     });
 
     const imports = [];

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -47,7 +47,7 @@ const compile = async function (args, opts) {
             Rule: {
                 import(rule) {
                     imports.push(rule.value.url);
-                    return [];
+                    return []; // Can't be removed
                 },
             },
         },

--- a/src/Bundlers/Bun/bin/plugins/css-loader.js
+++ b/src/Bundlers/Bun/bin/plugins/css-loader.js
@@ -1,5 +1,5 @@
-import { dd, error } from "./../utils/dump";
 import determineTargets from "./../utils/browser-targets";
+import { error } from "./../utils/dump";
 import { readFile } from "fs/promises";
 
 const defaultOptions = {
@@ -12,7 +12,6 @@ export default function (options = {}) {
     return {
         name: "css-loader",
         async setup(build) {
-
             // Compile plain css with Lightning CSS
             build.onLoad({ filter: /\.css$/ }, async (args) => {
                 const source = await readFile(args.path, "utf8");
@@ -30,11 +29,11 @@ export default function (options = {}) {
 
             // Compile sass pass output through Lightning CSS
             build.onLoad({ filter: /\.scss$/ }, async (args) => {
-                const sass = await import('sass').catch(error => {
-                    error('sass-not-installed')
-                })
+                const sass = await import("sass").catch((error) => {
+                    error("sass-not-installed");
+                });
 
-                const source = sass.compile(args.path)
+                const source = sass.compile(args.path);
 
                 const expression = await compile(source.css, args.path, {
                     ...defaultOptions,
@@ -51,10 +50,9 @@ export default function (options = {}) {
 }
 
 const compile = async function (source, filename, opts) {
-
-    const lightningcss = await import("lightningcss-wasm").catch(error => {
-        error('lightningcss-not-installed')
-    })
+    const lightningcss = await import("lightningcss-wasm").catch((error) => {
+        error("lightningcss-not-installed");
+    });
 
     const imports = [];
     const targets = await determineTargets(opts.browserslist);
@@ -90,8 +88,7 @@ const compile = async function (source, filename, opts) {
         .map((url, i) => `import _css${i} from "${url}";`)
         .join("\n");
 
-    const exported = imports.map((_, i) => `_css${i}`)
-        .join(" + ");
+    const exported = imports.map((_, i) => `_css${i}`).join(" + ");
 
     return `${imported}\nexport default ${exported} + ${css}`;
 };

--- a/src/Bundlers/Bun/bin/utils/browser-targets.js
+++ b/src/Bundlers/Bun/bin/utils/browser-targets.js
@@ -1,0 +1,64 @@
+import { browserslistToTargets } from "lightningcss-wasm";
+import { readFile, exists } from "fs/promises";
+import path from "path";
+
+/**
+ * Use targets from config or when none given try
+ * to detect browserslist from package.json
+ */
+export default async function (browserslist) {
+    // If config was given, return browserlist immediately
+    if (browserslist?.length) {
+        return browserslistToTargets(browserslist);
+    }
+
+    // Otherwise read from package.json
+    const pkg = await packageJson();
+    browserslist = pkg.browserslist || [];
+
+    if (browserslist?.length) {
+        return browserslistToTargets(browserslist);
+    }
+
+    // If no package.json found or browserslist was not defined
+    return undefined;
+}
+
+/**
+ * Get contents of nearest package.json
+ */
+async function packageJson() {
+    try {
+        const path = await findNearestPackageJson();
+        const content = await readFile(path, "utf8");
+        return JSON.parse(content);
+    } catch (error) {
+        console.error(
+            "Error reading browserslist from package.json:",
+            error.message
+        );
+        return [];
+    }
+}
+
+/**
+ * Get path of nearest package.json
+ */
+async function findNearestPackageJson() {
+    let currentDir = process.cwd();
+
+    while (true) {
+        const packageJsonPath = path.join(currentDir, "package.json");
+
+        if (await exists(packageJsonPath)) {
+            return packageJsonPath;
+        }
+
+        // package.json file could not be found.
+        if (currentDir === path.dirname(currentDir)) {
+            return null;
+        }
+
+        currentDir = path.dirname(currentDir);
+    }
+}

--- a/src/Bundlers/Bun/bin/utils/browser-targets.js
+++ b/src/Bundlers/Bun/bin/utils/browser-targets.js
@@ -45,7 +45,12 @@ async function packageJson() {
  * Get path of nearest package.json
  */
 async function findNearestPackageJson() {
+
     let currentDir = process.cwd();
+
+    if(process.env['APP_ENV'] === 'testing') {
+        currentDir += '/workbench';
+    }
 
     while (true) {
         const packageJsonPath = path.join(currentDir, "package.json");

--- a/src/Bundlers/Bun/bin/utils/dd.js
+++ b/src/Bundlers/Bun/bin/utils/dd.js
@@ -1,0 +1,4 @@
+export default function(output) {
+    console.error(output);
+    process.exit(1);
+}

--- a/src/Bundlers/Bun/bin/utils/dd.js
+++ b/src/Bundlers/Bun/bin/utils/dd.js
@@ -1,4 +1,0 @@
-export default function(output) {
-    console.error(output);
-    process.exit(1);
-}

--- a/src/Bundlers/Bun/bin/utils/dump.js
+++ b/src/Bundlers/Bun/bin/utils/dump.js
@@ -3,11 +3,15 @@ export function dd(output) {
     process.exit(1);
 }
 
-export function error(id, output = '') {
-    console.error({
-        id: 'bundle:' + id,
-        output
-    });
+/** Outputs a object to be caught by BundlingFailedException */
+export function error(id, message = "", output = "") {
+    console.error(
+        JSON.stringify({
+            id: "bundle:" + id,
+            message,
+            output,
+        })
+    );
 
     process.exit(1);
 }

--- a/src/Bundlers/Bun/bin/utils/dump.js
+++ b/src/Bundlers/Bun/bin/utils/dump.js
@@ -1,0 +1,13 @@
+export function dd(output) {
+    console.error(output);
+    process.exit(1);
+}
+
+export function error(id, output = '') {
+    console.error({
+        id: 'bundle:' + id,
+        output
+    });
+
+    process.exit(1);
+}

--- a/src/Bundlers/Bun/bin/utils/dump.js
+++ b/src/Bundlers/Bun/bin/utils/dump.js
@@ -4,7 +4,7 @@ export function dd(output) {
 }
 
 /** Outputs a object to be caught by BundlingFailedException */
-export function error(id, message = "", output = "") {
+export function exit(id, message = "", output = "") {
     console.error(
         JSON.stringify({
             id: "bundle:" + id,

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -74,7 +74,7 @@ class Import extends Component
             (() => {
 
                 // Check if module is already loaded under a different alias
-                const previous = document.querySelector(`script[data-module="{$this->module}"`)
+                const previous = document.querySelector(`script[data-module="{$this->module}"]`)
 
                 // Was previously loaded & needs to be pushed to import map
                 if(previous && '{$this->as}') {
@@ -87,6 +87,7 @@ class Import extends Component
                 // Handle CSS injection & return early (no need to add css to import map)
                 if('{$this->module}'.endsWith('.css') || '{$this->module}'.endsWith('.scss')) {
                     return import('{$this->module}').then(result => {
+                        console.dir(result.default)
                         window.x_inject_styles(result.default, previous)
                     })
                 }

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -53,7 +53,7 @@ class Import extends Component
 
         return <<< HTML
             <!--[BUNDLE: {$this->as} from '{$this->module}']-->
-            <script data-module="{$this->module}" data-alias="{$this->as}">throw "BUNDLING ERROR: No module found at path '{$this->module}'"</script>
+            <script data-module="{$this->module}" data-alias="{$this->as}">throw "BUNDLING ERROR: {$e->consoleOutput()}"</script>
             <!--[ENDBUNDLE]>-->
         HTML;
     }

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -25,10 +25,10 @@ class Import extends Component
         }
     }
 
-    /** Builds the core JavaScript & packages it up in a bundle */
+    /** Builds the imported JavaScript & packages it up in a bundle */
     protected function bundle()
     {
-        $js = $this->core();
+        $js = $this->import();
 
         // Render script tag with bundled code
         return view('x-import::script', [
@@ -58,8 +58,8 @@ class Import extends Component
         HTML;
     }
 
-    /** Builds Bundle's core JavaScript */
-    protected function core(): string
+    /** Builds a bundle for the JavaScript import */
+    protected function import(): string
     {
         return <<< JS
             //--------------------------------------------------------------------------
@@ -82,6 +82,13 @@ class Import extends Component
                     if(previous.dataset.alias !== '{$this->as}') {
                         throw `BUNDLING ERROR: '{$this->as}' already imported as '\${previous.dataset.alias}'`
                     }
+                }
+
+                // Handle CSS injection & return early (no need to add css to import map)
+                if('{$this->module}'.endsWith('.css') || '{$this->module}'.endsWith('.scss')) {
+                    return import('{$this->module}').then(result => {
+                        window.x_inject_styles(result.default, previous)
+                    })
                 }
 
                 // Assign the import to the window.x_import_modules object (or invoke IIFE)

--- a/src/Components/Import.php
+++ b/src/Components/Import.php
@@ -87,7 +87,6 @@ class Import extends Component
                 // Handle CSS injection & return early (no need to add css to import map)
                 if('{$this->module}'.endsWith('.css') || '{$this->module}'.endsWith('.scss')) {
                     return import('{$this->module}').then(result => {
-                        console.dir(result.default)
                         window.x_inject_styles(result.default, previous)
                     })
                 }

--- a/src/Exceptions/BundlingFailedException.php
+++ b/src/Exceptions/BundlingFailedException.php
@@ -5,6 +5,7 @@
 namespace Leuverink\Bundle\Exceptions;
 
 use RuntimeException;
+use Illuminate\Support\Arr;
 use Spatie\Ignition\Contracts\Solution;
 use Spatie\Ignition\Contracts\BaseSolution;
 use Illuminate\Contracts\Process\ProcessResult;
@@ -19,7 +20,7 @@ class BundlingFailedException extends RuntimeException implements ProvidesSoluti
         $this->result = $result;
         $failed = $script ?? $result->command();
 
-        // dd($result->errorOutput());
+        // dd($this->output());
 
         parent::__construct(
             "Bundling failed: {$failed}",
@@ -28,14 +29,47 @@ class BundlingFailedException extends RuntimeException implements ProvidesSoluti
 
         // TODO: Consider different approach for providing contextual debug info
         if (app()->isLocal() && config()->get('app.debug')) {
-            dump(['error output', $result->errorOutput()]);
+            dump(['error output', $result->output()]);
         }
+    }
+
+    /** Format output as defined in error function in bin/utils/dump.js */
+    public function output(): object
+    {
+        $output = json_decode($this->result->errorOutput());
+        if (
+            gettype($output) === 'object' &&
+            property_exists($output, 'id') &&
+            property_exists($output, 'message') &&
+            property_exists($output, 'output')
+        ) {
+            return $output;
+        }
+
+        return (object) [
+            'id' => null,
+            'message' => '',
+            'output' => $this->result->errorOutput(),
+        ];
+    }
+
+    public function consoleOutput(): string
+    {
+        $output = $this->output();
+
+        if ($output->message) {
+            return $output->message;
+        }
+
+        return Arr::wrap($output->output)[0];
     }
 
     public function getSolution(): Solution
     {
         return match (true) {
             str_contains($this->result->errorOutput(), 'bun: No such file or directory') => $this->bunNotInstalledSolution(),
+            str_contains($this->output()->id, 'bundle:sass-not-installed') => $this->sassNotInstalledSolution(),
+            str_contains($this->output()->id, 'bundle:lightningcss-not-installed') => $this->lightningcssNotInstalledSolution(),
             str_contains($this->result->errorOutput(), 'error: Could not resolve') => $this->moduleNotResolvableSolution(),
             str_contains($this->result->errorOutput(), 'tsconfig.json: ENOENT') => $this->missingJsconfigFileSolution(),
             str_contains($this->result->errorOutput(), 'Cannot find tsconfig') => $this->missingJsconfigFileSolution(),
@@ -50,6 +84,20 @@ class BundlingFailedException extends RuntimeException implements ProvidesSoluti
         return BaseSolution::create()
             ->setSolutionTitle('Bun is not installed.')
             ->setSolutionDescription('Bun is not installed. Try running `npm install bun --save-dev`');
+    }
+
+    private function sassNotInstalledSolution()
+    {
+        return BaseSolution::create()
+            ->setSolutionTitle('Sass is not installed.')
+            ->setSolutionDescription('You need to install Sass in order to load .scss files. Try running `npm install sass --save-dev`');
+    }
+
+    private function lightningcssNotInstalledSolution()
+    {
+        return BaseSolution::create()
+            ->setSolutionTitle('Lightning CSS is not installed.')
+            ->setSolutionDescription('You need to install Lightning CSS in order to load .css files. Try running `npm install lightningcss --save-dev`');
     }
 
     private function moduleNotResolvableSolution()

--- a/src/Exceptions/BundlingFailedException.php
+++ b/src/Exceptions/BundlingFailedException.php
@@ -15,6 +15,8 @@ class BundlingFailedException extends RuntimeException implements ProvidesSoluti
 {
     public ProcessResult $result;
 
+    // TODO: needs to be reworked. It's getting too big & handles too many JS error cases
+    // Maybe split it up & devise a system that maps JS errors raised by Bun to appropriate Exception classes
     public function __construct(ProcessResult $result, $script = null)
     {
         $this->result = $result;

--- a/src/InjectCore.php
+++ b/src/InjectCore.php
@@ -140,6 +140,23 @@ class InjectCore
                 }
             };
 
+            //--------------------------------------------------------------------------
+            // Inject styles
+            //--------------------------------------------------------------------------
+            window.x_inject_styles = function (css, scriptTag) {
+                if (typeof document === 'undefined') {
+                    return;
+                }
+
+                // TODO: Add CSP nonce in style tags too when whe get implementing it
+                const style = document.createElement('style');
+                style.dataset['module'] = scriptTag.dataset['module'];
+                style.innerHTML = css;
+
+                // Inject the style tag after the script that invoked this function
+                scriptTag.parentNode.insertBefore(style, scriptTag.nextSibling);
+            }
+
         JS;
     }
 }

--- a/src/InjectCore.php
+++ b/src/InjectCore.php
@@ -148,7 +148,7 @@ class InjectCore
                     return;
                 }
 
-                // TODO: Add CSP nonce in style tags too when whe get implementing it
+                // TODO: Add CSP nonce when adding CSP support
                 const style = document.createElement('style');
                 style.dataset['module'] = scriptTag.dataset['module'];
                 style.innerHTML = css;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,12 +4,12 @@
 
 namespace Leuverink\Bundle;
 
-use Leuverink\Bundle\Bundlers\Bun;
 use Leuverink\Bundle\Commands\Build;
 use Leuverink\Bundle\Commands\Clear;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Leuverink\Bundle\Bundlers\Bun\Bun;
 use Leuverink\Bundle\Components\Import;
 use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;

--- a/tests/Browser/ComponentTest.php
+++ b/tests/Browser/ComponentTest.php
@@ -195,6 +195,6 @@ class ComponentTest extends DuskTestCase
             HTML)
             ->assertScript(<<< 'JS'
                 document.querySelector('script[data-module="~/nonexistent-module"').innerHTML
-            JS, 'throw "BUNDLING ERROR: No module found at path \'~/nonexistent-module\'"');
+            JS, 'throw "BUNDLING ERROR: Could not resolve: "~/nonexistent-module". Maybe you need to "bun install"?"');
     }
 }

--- a/tests/Browser/CssLoaderTest.php
+++ b/tests/Browser/CssLoaderTest.php
@@ -46,6 +46,8 @@ class CssLoaderTest extends DuskTestCase
     /** @test */
     public function it_handles_scss_files()
     {
+        $this->markTestSkipped('not implemented');
+
         $browser = $this->blade(<<< 'HTML'
             <x-import module="css/blue-background.scss" />
         HTML);

--- a/tests/Browser/CssLoaderTest.php
+++ b/tests/Browser/CssLoaderTest.php
@@ -135,4 +135,16 @@ class CssLoaderTest extends DuskTestCase
     {
         $this->markTestSkipped('not implemented');
     }
+
+    /** @test */
+    public function it_generates_scss_sourcemaps_when_enabled()
+    {
+        $this->markTestSkipped('not implemented');
+    }
+
+    /** @test */
+    public function it_doesnt_generate_scss_sourcemaps_by_default()
+    {
+        $this->markTestSkipped('not implemented');
+    }
 }

--- a/tests/Browser/CssLoaderTest.php
+++ b/tests/Browser/CssLoaderTest.php
@@ -44,10 +44,8 @@ class CssLoaderTest extends DuskTestCase
     }
 
     /** @test */
-    public function it_handles_scss_files()
+    public function it_supports_sass()
     {
-        $this->markTestSkipped('not implemented');
-
         $browser = $this->blade(<<< 'HTML'
             <x-import module="css/blue-background.scss" />
         HTML);
@@ -55,7 +53,7 @@ class CssLoaderTest extends DuskTestCase
         // Expect CSS rendered on page
         $browser->assertScript(
             'document.querySelector(`style[data-module="css/blue-background.scss"]`).innerHTML',
-            'html{& body{background:#00f}}'
+            'html body{background:#00f}'
         );
 
         // Doesn't raise console errors

--- a/tests/Browser/CssLoaderTest.php
+++ b/tests/Browser/CssLoaderTest.php
@@ -127,24 +127,86 @@ class CssLoaderTest extends DuskTestCase
     /** @test */
     public function it_generates_sourcemaps_when_enabled()
     {
-        $this->markTestSkipped('not implemented');
+        $this->beforeServingApplication(function ($app, $config) {
+            $config->set('bundle.minify', true);
+            $config->set('bundle.sourcemaps', true);
+        });
+
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/red-background.css" />
+        HTML);
+
+        // Assert output contains encoded sourcemap (flaky. asserting on encoded sting)
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/red-background.css"]`).innerHTML.startsWith("html{background:red}\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VSb290IjpudWxsLCJtYXBwaW5ncyI6IkFBQUEi")',
+            true
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
     }
 
     /** @test */
     public function it_doesnt_generate_sourcemaps_by_default()
     {
-        $this->markTestSkipped('not implemented');
+        $this->beforeServingApplication(function ($app, $config) {
+            $config->set('bundle.minify', true);
+            $config->set('bundle.sourcemaps', false);
+        });
+
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/red-background.css" />
+        HTML);
+
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/red-background.css"]`).innerHTML',
+            'html{background:red}'
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
     }
 
     /** @test */
     public function it_generates_scss_sourcemaps_when_enabled()
     {
-        $this->markTestSkipped('not implemented');
+        $this->beforeServingApplication(function ($app, $config) {
+            $config->set('bundle.minify', true);
+            $config->set('bundle.sourcemaps', true);
+        });
+
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/blue-background.scss" />
+        HTML);
+
+        // Assert output contains encoded sourcemap (flaky. asserting on encoded sting)
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/blue-background.scss"]`).innerHTML.startsWith("html body{background:#00f}\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VSb290Ij")',
+            true
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
     }
 
     /** @test */
     public function it_doesnt_generate_scss_sourcemaps_by_default()
     {
-        $this->markTestSkipped('not implemented');
+        $this->beforeServingApplication(function ($app, $config) {
+            $config->set('bundle.minify', true);
+            $config->set('bundle.sourcemaps', false);
+        });
+
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/blue-background.scss" />
+        HTML);
+
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/blue-background.scss"]`).innerHTML',
+            'html body{background:#00f}'
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
     }
 }

--- a/tests/Browser/CssLoaderTest.php
+++ b/tests/Browser/CssLoaderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Leuverink\Bundle\Tests\Browser;
+
+use Leuverink\Bundle\Tests\DuskTestCase;
+
+// Pest & Workbench Dusk don't play nicely together
+// We need to fall back to PHPUnit syntax.
+
+class CssLoaderTest extends DuskTestCase
+{
+    /** @test */
+    public function it_injects_a_style_tag_on_the_page()
+    {
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/red-background.css" />
+        HTML);
+
+        // Expect CSS rendered on page
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/red-background.css"]`).innerHTML',
+            'html{background:red}'
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
+    }
+
+    /** @test */
+    public function it_handles_css_files()
+    {
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/red-background.css" />
+        HTML);
+
+        // Expect CSS rendered on page
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/red-background.css"]`).innerHTML',
+            'html{background:red}'
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
+    }
+
+    /** @test */
+    public function it_handles_scss_files()
+    {
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/blue-background.scss" />
+        HTML);
+
+        // Expect CSS rendered on page
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/blue-background.scss"]`).innerHTML',
+            'html{& body{background:#00f}}'
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
+    }
+
+    /** @test */
+    public function it_processes_css_imports()
+    {
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/imported-red-background.css" />
+        HTML);
+
+        // Expect CSS rendered on page
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/imported-red-background.css"]`).innerHTML',
+            'html{background:red}'
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
+    }
+
+    /** @test */
+    public function it_minifies_css_when_minification_enabled()
+    {
+        $this->beforeServingApplication(function ($app, $config) {
+            $config->set('bundle.minify', true);
+        });
+
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/red-background.css" />
+        HTML);
+
+        // Expect CSS rendered on page
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/red-background.css"]`).innerHTML',
+            'html{background:red}'
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
+    }
+
+    /** @test */
+    public function it_doesnt_minify_css_when_minification_disabled()
+    {
+        $this->beforeServingApplication(function ($app, $config) {
+            $config->set('bundle.minify', false);
+        });
+
+        $browser = $this->blade(<<< 'HTML'
+            <x-import module="css/red-background.css" />
+        HTML);
+
+        // Expect CSS rendered on page
+        $browser->assertScript(
+            'document.querySelector(`style[data-module="css/red-background.css"]`).innerHTML',
+            <<< 'CSS'
+            html {
+              background: red;
+            }
+
+            CSS
+        );
+
+        // Doesn't raise console errors
+        $this->assertEmpty($browser->driver->manage()->getLog('browser'));
+    }
+
+    /** @test */
+    public function it_generates_sourcemaps_when_enabled()
+    {
+        $this->markTestSkipped('not implemented');
+    }
+
+    /** @test */
+    public function it_doesnt_generate_sourcemaps_by_default()
+    {
+        $this->markTestSkipped('not implemented');
+    }
+}

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -63,6 +63,8 @@ class DuskTestCase extends BaseTestCase
         // Create a temporary route
         $this->beforeServingApplication(function ($app, $config) use ($page) {
             $config->set('app.debug', true);
+            $config->set('bundle.cache_control_headers', 'no-cache, no-store, must-revalidate');
+
             $app->make(Route::class)::get('test-blade', fn () => $page);
         });
 
@@ -87,6 +89,7 @@ class DuskTestCase extends BaseTestCase
         $this->beforeServingApplication(function ($app, $config) use (&$component) {
             $config->set('app.debug', true);
             $config->set('app.key', 'base64:q1fQla64BmAKJBOnRKuXvfddVoqEuSLv1eOEEO91uGI=');
+            $config->set('bundle.cache_control_headers', 'no-cache, no-store, must-revalidate');
 
             // Needs to register so component is findable in update calls
             Livewire::component($component);

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -15,18 +15,18 @@ class DuskTestCase extends BaseTestCase
 {
     use WithWorkbench;
 
+    public static function setUpBeforeClass(): void
+    {
+        Options::withoutUI();
+        parent::setUpBeforeClass();
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->artisan('view:clear');
         $this->artisan('bundle:clear');
-    }
-
-    public static function setUpBeforeClass(): void
-    {
-        Options::withoutUI();
-        parent::setUpBeforeClass();
     }
 
     protected function tearDown(): void

--- a/tests/Feature/IntegrationTest.php
+++ b/tests/Feature/IntegrationTest.php
@@ -50,7 +50,7 @@ it('supports tree shaking for variables')->bundle(
 
 it('generates sourcemaps when enabled')
     ->defer(
-        fn () => config()->set('bundle.sourcemaps_enabled', true)
+        fn () => config()->set('bundle.sourcemaps', true)
     )
     ->bundle(
         <<< 'JS'

--- a/tests/Feature/IntegrationTest.php
+++ b/tests/Feature/IntegrationTest.php
@@ -120,7 +120,7 @@ it('logs console error when blade component fails bundling and debug mode is dis
     expect($component->render())
         ->toContain(
             'throw',
-            "BUNDLING ERROR: No module found at path '~/foo'"
+            'BUNDLING ERROR: Could not resolve: "~/foo". Maybe you need to "bun install"?'
         )
         ->not->toThrow(BundlingFailedException::class);
 });

--- a/workbench/jsconfig.json
+++ b/workbench/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "paths": {
-      "~/*": ["./resources/js/*"]
+      "~/*": ["./resources/js/*"],
+      "css/*": ["./resources/css/*"]
     }
   }
 }

--- a/workbench/package.json
+++ b/workbench/package.json
@@ -1,4 +1,9 @@
 {
+  "browserslist": [
+    "last 2 versions",
+    ">= 1%",
+    "IE 11"
+  ],
   "devDependencies": {
     "bun": "^1.0.21",
     "lodash": "^4.17.21",

--- a/workbench/resources/css/blue-background.scss
+++ b/workbench/resources/css/blue-background.scss
@@ -1,0 +1,5 @@
+html {
+    body {
+        background: blue;
+    }
+}

--- a/workbench/resources/css/blue-background.scss
+++ b/workbench/resources/css/blue-background.scss
@@ -1,5 +1,7 @@
+$bg_color: blue;
+
 html {
     body {
-        background: blue;
+        background: $bg_color;
     }
 }

--- a/workbench/resources/css/imported-red-background.css
+++ b/workbench/resources/css/imported-red-background.css
@@ -1,0 +1,1 @@
+@import "./red-background.css";

--- a/workbench/resources/css/red-background.css
+++ b/workbench/resources/css/red-background.css
@@ -1,0 +1,3 @@
+html {
+  background: red;
+}


### PR DESCRIPTION
This PR adds a basic CSS loader that should cover most use cases (needs lightningcss as a dependency)

Sass is also supported, but needs to be installed separately

- [x] update docs
- [x] import .css files
- [x] import .scss files
- [x] support css imports
- [x] support minification
- [x] support browser targeting
- [x] supports CSS sourcemaps
- [x] supports Sass sourcemaps
- [x] automatically injects css into the DOM
- [x] add tests for css loading (scss, css & assert dom)
- [x] add tests for config options (minify & etc)
- [x] check for missing dependencies (only when needed) and throw appropriate exceptions (needs to be reworked in separate PR)
- [x] Improve docs (Explain Bun's auto install feature - [module resolution algorithm](https://bun.sh/docs/runtime/autoimport))
